### PR TITLE
Support example keyword in Lean declarations

### DIFF
--- a/src/ax_prover/models/declaration.py
+++ b/src/ax_prover/models/declaration.py
@@ -31,6 +31,15 @@ class DeclarationType(StrEnum):
     Section = "section"
     Namespace = "namespace"
     Import = "import"
+    Example = "example"
+
+    @property
+    def is_anonymous(self) -> bool:
+        """Whether this declaration type has no name (e.g., example)."""
+        return self in _ANONYMOUS_TYPES
+
+
+_ANONYMOUS_TYPES = {DeclarationType.Example}
 
 
 class Declaration(BaseModel):

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -15,6 +15,8 @@ logger = get_logger(__name__)
 
 # Lean keywords for declarations
 LEAN_KEYWORDS = [d.value for d in DeclarationType]
+LEAN_KEYWORDS_SET = set(LEAN_KEYWORDS)
+ANONYMOUS_KEYWORDS = {d.value for d in DeclarationType if d.is_anonymous}
 
 
 def count_sorries(content: str, context_lines: int = 1) -> tuple[int, list[tuple[int, str]]]:
@@ -132,7 +134,11 @@ def extract_function_from_content(content: str, function_name: str) -> str | Non
         The complete definition block including doc comments, or None
     """
     keywords_pattern = "|".join(LEAN_KEYWORDS)
-    pattern = rf"^(\s*)({keywords_pattern})\s+{re.escape(function_name)}\b"
+
+    if function_name in ANONYMOUS_KEYWORDS:
+        pattern = rf"^(\s*)({re.escape(function_name)})\b"
+    else:
+        pattern = rf"^(\s*)({keywords_pattern})\s+{re.escape(function_name)}\b"
 
     match = re.search(pattern, content, re.MULTILINE)
     if not match:
@@ -304,10 +310,13 @@ def extract_theorem_name(theorem_statement: str) -> str | None:
     theorem_statement = strip_comments(theorem_statement)
 
     keywords_pattern = "|".join(re.escape(kw) for kw in LEAN_KEYWORDS)
-    match = re.search(rf"\b(?:{keywords_pattern})\s+([\w.]+)", theorem_statement)
-    if match:
-        return match.group(1)
-    return None
+    match = re.search(rf"\b({keywords_pattern})(?:\s+([\w.]+))?", theorem_statement)
+    if not match:
+        return None
+    keyword, name = match.group(1), match.group(2)
+    if name:
+        return name
+    return keyword if keyword in ANONYMOUS_KEYWORDS else None
 
 
 def list_all_declarations_in_lean_code(raw_code: str) -> list[Declaration]:
@@ -327,14 +336,19 @@ def list_all_declarations_in_lean_code(raw_code: str) -> list[Declaration]:
 
     for line in code.split("\n"):
         line_keywords = line.strip().split()
-        if len(line_keywords) >= 2 and line_keywords[0] in list(DeclarationType):
-            # Extract just the name, splitting on punctuation that can follow it
-            name = re.split(r"[:({[\[]", line_keywords[1])[0]
-            content = line_keywords[2:]
+        keyword = line_keywords[0] if line_keywords else None
+        is_anon = keyword in ANONYMOUS_KEYWORDS
+        if keyword in LEAN_KEYWORDS_SET and (is_anon or len(line_keywords) >= 2):
+            if is_anon:
+                name = keyword
+                content = line_keywords[1:]
+            else:
+                name = re.split(r"[:({[\[]", line_keywords[1])[0]
+                content = line_keywords[2:]
             if declaration is not None:
                 declarations.append(declaration)
             declaration = Declaration(
-                declaration_type=line_keywords[0],
+                declaration_type=keyword,
                 name=name,
                 content=" ".join(content),
             )
@@ -435,24 +449,28 @@ def find_declaration_at_line(content: str, line_number: int) -> str | None:
         return None
 
     keywords_pattern = "|".join(LEAN_KEYWORDS)
-    pattern = rf"^(\s*)({keywords_pattern})\s+([\w.]+)"
+    pattern = rf"^(\s*)({keywords_pattern})(?:\s+([\w.]+))?"
 
     declarations: list[tuple[str, int, int]] = []
 
     for i, line in enumerate(lines):
         match = re.match(pattern, line)
-        if match:
-            name = match.group(3)
-            # Split on punctuation that can follow the name
-            name = re.split(r"[:({[\[]", name)[0]
-            start_line = i + 1  # Convert to 1-indexed
+        if not match:
+            continue
+        keyword, name = match.group(2), match.group(3)
+        if not name:
+            if keyword not in ANONYMOUS_KEYWORDS:
+                continue
+            name = keyword
+        name = re.split(r"[:({[\[]", name)[0]
+        start_line = i + 1  # Convert to 1-indexed
 
-            # Close previous declaration at same or lower indent
-            if declarations:
-                prev_name, prev_start, _ = declarations[-1]
-                declarations[-1] = (prev_name, prev_start, i + 1)  # end is exclusive, 1-indexed
+        # Close previous declaration at same or lower indent
+        if declarations:
+            prev_name, prev_start, _ = declarations[-1]
+            declarations[-1] = (prev_name, prev_start, i + 1)  # end is exclusive, 1-indexed
 
-            declarations.append((name, start_line, len(lines) + 1))
+        declarations.append((name, start_line, len(lines) + 1))
 
     for name, start, end in declarations:
         if start <= line_number < end:

--- a/test_example_keyword.py
+++ b/test_example_keyword.py
@@ -1,0 +1,13 @@
+"""Smoke test: ax-prover prove on a Lean `example` declaration."""
+
+import subprocess
+import sys
+
+FOLDER = "/private/tmp/test_example_lean"
+TARGET = "TestExample.Basic:example"
+
+result = subprocess.run(
+    ["ax-prover", "prove", TARGET, "--folder", FOLDER, "--skip-build"],
+    cwd="/Users/leopoldo/local/ax-prover-base",
+)
+sys.exit(result.returncode)

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -34,6 +34,16 @@ lemma helper_lemma (n : Nat) : n + 0 = n := by
   sorry
 """
 
+EXAMPLE_LEAN_CODE = """\
+import Mathlib.Topology.Basic
+
+example : 2 + 3 = 5 := by
+  sorry
+
+theorem after_example (n : Nat) : n = n := by
+  rfl
+"""
+
 NESTED_COMMENT_CODE = """\
 /- outer /- inner -/ still outer -/
 def foo := 1
@@ -201,6 +211,20 @@ class TestExtractFunctionFromContent:
         assert result is not None
         assert "Poly.not_principal" in result
 
+    def test_extract_example(self):
+        """Extracts an example declaration from Lean code."""
+        code = "example : 2 + 3 = 5 := by\n  sorry"
+        result = extract_function_from_content(code, "example")
+        assert result is not None
+        assert "2 + 3 = 5" in result
+
+    def test_example_does_not_break_surrounding_declarations(self):
+        """Declarations after an example are still extractable."""
+        result = extract_function_from_content(EXAMPLE_LEAN_CODE, "after_example")
+        assert result is not None
+        assert "theorem after_example" in result
+        assert "rfl" in result
+
 
 # --- extract_theorem_name ---
 
@@ -226,6 +250,10 @@ class TestExtractTheoremName:
     def test_extract_theorem_name(self, stmt, expected):
         """Extracts theorem name from various declaration types."""
         assert extract_theorem_name(stmt) == expected
+
+    def test_extract_example_name(self):
+        """extract_theorem_name returns 'example' for anonymous example declarations."""
+        assert extract_theorem_name("example : 2 + 3 = 5 := by sorry") == "example"
 
 
 # --- list_all_declarations_in_lean_code ---
@@ -268,6 +296,19 @@ class TestListAllDeclarationsInLeanCode:
         names = [d.name for d in declarations]
         assert "visible" in names
         assert "hidden" not in names
+
+    def test_example_declaration_detected(self):
+        """Example declarations are detected by list_all_declarations_in_lean_code."""
+        code = "example : 2 + 3 = 5 := by\n  sorry\n\ntheorem foo : True := trivial"
+        declarations = list_all_declarations_in_lean_code(code)
+        types = [d.declaration_type for d in declarations]
+        assert DeclarationType.Example in types
+
+    def test_declarations_after_example_still_found(self):
+        """Declarations following an example are still correctly parsed."""
+        declarations = list_all_declarations_in_lean_code(EXAMPLE_LEAN_CODE)
+        names = [d.name for d in declarations]
+        assert "after_example" in names
 
 
 # --- normalize_location ---


### PR DESCRIPTION
Introduce support for the `example` keyword in Lean declarations, allowing for proper extraction and handling of example declarations in the code. Update related functions and tests to ensure correct functionality and detection of example declarations.