### PR TITLE
Detect axioms and search tactics public

### DIFF
--- a/src/ax_prover/models/messages.py
+++ b/src/ax_prover/models/messages.py
@@ -180,6 +180,45 @@ class SorriesGoalStateFeedback(FeedbackMessage):
         )
 
 
+class AxiomDetectedFeedback(FeedbackMessage):
+    """Proposed code introduces new axioms."""
+
+    feedback_type: Literal["axiom_detected"] = "axiom_detected"
+    count: int
+    locations: str
+    is_success: bool = False
+
+    def __init__(self, count: int, locations: str, **kwargs):
+        """Initialize with formatted axiom detection message."""
+        kwargs.pop("content", None)
+        content = (
+            f"AXIOM DETECTED: The proposed code introduces {count} new axiom declaration(s). "
+            "Introducing new axioms is forbidden — you must prove the theorem without axioms.\n\n"
+            f"Locations:\n{locations}"
+        )
+        super().__init__(content=content, count=count, locations=locations, **kwargs)
+
+
+class SearchTacticsDetectedFeedback(FeedbackMessage):
+    """Proposed code contains search tactics like apply? or exact?."""
+
+    feedback_type: Literal["search_tactics_detected"] = "search_tactics_detected"
+    count: int
+    locations: str
+    is_success: bool = False
+
+    def __init__(self, count: int, locations: str, **kwargs):
+        """Initialize with formatted search tactics detection message."""
+        kwargs.pop("content", None)
+        content = (
+            f"SEARCH TACTICS DETECTED: The proposed code contains {count} search tactic(s) "
+            "(apply?, exact?, etc.). Search tactics are not allowed in final proofs — "
+            "replace them with the concrete tactics they suggest.\n\n"
+            f"Locations:\n{locations}"
+        )
+        super().__init__(content=content, count=count, locations=locations, **kwargs)
+
+
 class StructuredOutputParsingFailedFeedback(FeedbackMessage):
     """Structured output parsing failed - LLM couldn't produce valid output."""
 

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -403,7 +403,9 @@ class ProverAgent:
             if build_success:
                 self.logger.info("Build successful")
 
-                if sorry_count := count_pattern(state.last_proposal.code, pattern=r"\b(sorry|admit)\b")[0]:
+                if sorry_count := count_pattern(
+                    state.last_proposal.code, pattern=r"\b(sorry|admit)\b"
+                )[0]:
                     self.logger.info("The proposed code contains sorries.")
                     goal_state_at_sorries = await get_goal_state_at_sorries(
                         self.base_folder,

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -418,9 +418,7 @@ class ProverAgent:
 
                 stripped_code = strip_comments(state.last_proposal.code)
 
-                axiom_count, axiom_locations = count_sorries(
-                    stripped_code, pattern=r"\baxiom\b"
-                )
+                axiom_count, axiom_locations = count_sorries(stripped_code, pattern=r"\baxiom\b")
                 if axiom_count:
                     self.logger.info("The proposed code introduces axiom declarations.")
                     formatted = "\n".join(ctx for _, ctx in axiom_locations)

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -13,6 +13,7 @@ from langgraph.graph.state import CompiledStateGraph
 from ..config import ProverConfig, RuntimeConfig
 from ..models import ProverAgentState
 from ..models.messages import (
+    AxiomDetectedFeedback,
     BuildFailedFeedback,
     BuildSuccessFeedback,
     FeedbackMessage,
@@ -22,6 +23,7 @@ from ..models.messages import (
     ProposalMessage,
     ReviewApprovedFeedback,
     ReviewRejectedFeedback,
+    SearchTacticsDetectedFeedback,
     SorriesGoalStateFeedback,
     StructuredOutputParsingFailedFeedback,
 )
@@ -48,6 +50,7 @@ from ..utils.lean_interact import get_goal_state_at_sorries
 from ..utils.lean_parsing import (
     find_declaration_by_name,
     list_all_declarations_in_lean_code,
+    strip_comments,
 )
 from ..utils.llm import (
     ainvoke_retry_with_structured_output,
@@ -410,6 +413,28 @@ class ProverAgent:
                     feedback = SorriesGoalStateFeedback(
                         sorry_count=sorry_count,
                         goal_state_at_sorries=goal_state_at_sorries,
+                    )
+                    return {"messages": [feedback]}
+
+                stripped_code = strip_comments(state.last_proposal.code)
+
+                axiom_count, axiom_locations = count_sorries(
+                    stripped_code, pattern=r"\baxiom\b"
+                )
+                if axiom_count:
+                    self.logger.info("The proposed code introduces axiom declarations.")
+                    formatted = "\n".join(ctx for _, ctx in axiom_locations)
+                    feedback = AxiomDetectedFeedback(count=axiom_count, locations=formatted)
+                    return {"messages": [feedback]}
+
+                tactic_count, tactic_locations = count_sorries(
+                    stripped_code, pattern=r"\b(apply|exact)\?"
+                )
+                if tactic_count:
+                    self.logger.info("The proposed code contains search tactics.")
+                    formatted = "\n".join(ctx for _, ctx in tactic_locations)
+                    feedback = SearchTacticsDetectedFeedback(
+                        count=tactic_count, locations=formatted
                     )
                     return {"messages": [feedback]}
 

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -32,7 +32,7 @@ from ..tools import create_tool
 from ..utils import (
     attach_builder_files,
     attach_prover_logs_if_enabled,
-    count_sorries,
+    count_pattern,
     get_function_from_location,
     get_git_hash,
     get_logger,
@@ -403,7 +403,7 @@ class ProverAgent:
             if build_success:
                 self.logger.info("Build successful")
 
-                if sorry_count := count_sorries(state.last_proposal.code)[0]:
+                if sorry_count := count_pattern(state.last_proposal.code, pattern=r"\b(sorry|admit)\b")[0]:
                     self.logger.info("The proposed code contains sorries.")
                     goal_state_at_sorries = await get_goal_state_at_sorries(
                         self.base_folder,
@@ -418,14 +418,14 @@ class ProverAgent:
 
                 stripped_code = strip_comments(state.last_proposal.code)
 
-                axiom_count, axiom_locations = count_sorries(stripped_code, pattern=r"\baxiom\b")
+                axiom_count, axiom_locations = count_pattern(stripped_code, pattern=r"\baxiom\b")
                 if axiom_count:
                     self.logger.info("The proposed code introduces axiom declarations.")
                     formatted = "\n".join(ctx for _, ctx in axiom_locations)
                     feedback = AxiomDetectedFeedback(count=axiom_count, locations=formatted)
                     return {"messages": [feedback]}
 
-                tactic_count, tactic_locations = count_sorries(
+                tactic_count, tactic_locations = count_pattern(
                     stripped_code, pattern=r"\b(apply|exact)\?"
                 )
                 if tactic_count:

--- a/src/ax_prover/utils/__init__.py
+++ b/src/ax_prover/utils/__init__.py
@@ -63,7 +63,7 @@ __all__ = [
     "is_git_dirty",
     # Lean
     "LEAN_KEYWORDS",
-    "count_sorries",
+    "count_pattern",
     "strip_comments",
     # Proving
     "get_item_from_line",

--- a/src/ax_prover/utils/__init__.py
+++ b/src/ax_prover/utils/__init__.py
@@ -7,7 +7,7 @@ from .git import get_git_hash, get_repo_metadata, is_git_dirty
 # Export Lean parsing utilities
 from .lean_parsing import (
     LEAN_KEYWORDS,
-    count_sorries,
+    count_pattern,
     extract_function_from_content,
     extract_theorem_name,
     get_function_from_location,

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -17,12 +17,17 @@ logger = get_logger(__name__)
 LEAN_KEYWORDS = [d.value for d in DeclarationType]
 
 
-def count_sorries(content: str, context_lines: int = 1) -> tuple[int, list[tuple[int, str]]]:
-    """Count 'sorry' and 'admit' statements in Lean code with context.
+def count_sorries(
+    content: str,
+    context_lines: int = 1,
+    pattern: str = r"\b(sorry|admit)\b",
+) -> tuple[int, list[tuple[int, str]]]:
+    """Count pattern matches in Lean code with context.
 
     Args:
         content: The Lean file content
         context_lines: Number of lines to show before and after
+        pattern: Regex pattern to search for (default: sorry/admit)
 
     Returns:
         Tuple of (count, locations) where locations is a list of (line_num, formatted_context)
@@ -31,7 +36,7 @@ def count_sorries(content: str, context_lines: int = 1) -> tuple[int, list[tuple
     lines = content.splitlines()
 
     for i, line in enumerate(lines):
-        for match in re.finditer(r"\b(sorry|admit)\b", line):
+        for match in re.finditer(pattern, line):
             line_num = i + 1
             col = match.start()
 

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -17,10 +17,10 @@ logger = get_logger(__name__)
 LEAN_KEYWORDS = [d.value for d in DeclarationType]
 
 
-def count_sorries(
+def count_pattern(
     content: str,
+    pattern: str,
     context_lines: int = 1,
-    pattern: str = r"\b(sorry|admit)\b",
 ) -> tuple[int, list[tuple[int, str]]]:
     """Count pattern matches in Lean code with context.
 

--- a/src/ax_prover/utils/proving.py
+++ b/src/ax_prover/utils/proving.py
@@ -9,7 +9,7 @@ from ..models import TargetItem
 from ..models.files import Location
 from ..models.proving import ProverAgentState
 from .lean_parsing import (
-    count_sorries,
+    count_pattern,
     find_declaration_at_line,
     get_function_from_location,
     get_unproven,
@@ -35,7 +35,7 @@ def get_item_from_location(folder: str, location_str: str) -> TargetItem | None:
         logger.error(f"Theorem not found: {location.formatted_context}")
         return None
 
-    sorry_count, _ = count_sorries(theorem_content)
+    sorry_count, _ = count_pattern(theorem_content, pattern=r"\b(sorry|admit)\b")
     logger.debug(f"Found theorem with {sorry_count} sorrie(s)")
 
     item = TargetItem(

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -4,7 +4,7 @@ import pytest
 
 from ax_prover.models.declaration import Declaration, DeclarationType
 from ax_prover.utils.lean_parsing import (
-    count_sorries,
+    count_pattern,
     extract_function_from_content,
     extract_theorem_name,
     find_declaration_by_name,
@@ -149,39 +149,41 @@ class TestStripComments:
         assert "def foo := 1" in result
 
 
-class TestCountSorries:
-    """Tests for count_sorries function."""
+class TestCountPattern:
+    """Tests for count_pattern function."""
+
+    SORRY_PATTERN = r"\b(sorry|admit)\b"
 
     def test_no_sorries(self):
         """Clean code returns count 0."""
         code = "def foo := 42\ndef bar := 1 + 2"
-        count, locations = count_sorries(code)
+        count, locations = count_pattern(code, pattern=self.SORRY_PATTERN)
         assert count == 0
         assert locations == []
 
     def test_single_sorry(self):
         """One sorry is detected with correct line number."""
         code = "def foo := by\n  sorry"
-        count, locations = count_sorries(code)
+        count, locations = count_pattern(code, pattern=self.SORRY_PATTERN)
         assert count == 1
         assert locations[0][0] == 2  # line number
 
     def test_multiple_sorries(self):
         """Multiple sorries on different lines are all found."""
         code = "def foo := by\n  sorry\ndef bar := by\n  sorry"
-        count, _ = count_sorries(code)
+        count, _ = count_pattern(code, pattern=self.SORRY_PATTERN)
         assert count == 2
 
     def test_sorry_and_admit(self):
         """Both 'sorry' and 'admit' are detected."""
         code = "def foo := by\n  sorry\ndef bar := by\n  admit"
-        count, locations = count_sorries(code)
+        count, locations = count_pattern(code, pattern=self.SORRY_PATTERN)
         assert count == 2
 
     def test_context_lines(self):
         """Context lines around sorry are included."""
         code = "-- before\ndef foo := by\n  sorry\n-- after"
-        _, locations = count_sorries(code, context_lines=1)
+        _, locations = count_pattern(code, pattern=self.SORRY_PATTERN, context_lines=1)
         context_text = locations[0][1]
         assert "def foo" in context_text
         assert "sorry" in context_text
@@ -189,32 +191,32 @@ class TestCountSorries:
     def test_sorry_in_word_not_counted(self):
         """Words containing 'sorry' (e.g., 'sorry_lemma') are not counted."""
         code = "def sorry_lemma := 42"
-        count, _ = count_sorries(code)
+        count, _ = count_pattern(code, pattern=self.SORRY_PATTERN)
         assert count == 0
 
     def test_custom_pattern_detects_axiom(self):
         """Custom pattern detects axiom declarations."""
         code = "axiom myAxiom : Nat → Nat\ntheorem foo : True := trivial"
-        count, locations = count_sorries(code, pattern=r"\baxiom\b")
+        count, locations = count_pattern(code, pattern=r"\baxiom\b")
         assert count == 1
         assert locations[0][0] == 1
 
     def test_custom_pattern_detects_search_tactics(self):
         """Custom pattern detects apply? and exact?."""
         code = "theorem foo : P := by\n  apply?\n  exact?"
-        count, _ = count_sorries(code, pattern=r"\b(apply|exact)\?")
+        count, _ = count_pattern(code, pattern=r"\b(apply|exact)\?")
         assert count == 2
 
     def test_custom_pattern_does_not_flag_apply_without_question_mark(self):
         """apply (without ?) is not flagged by the search tactics pattern."""
         code = "theorem foo : P := by\n  apply some_lemma"
-        count, _ = count_sorries(code, pattern=r"\b(apply|exact)\?")
+        count, _ = count_pattern(code, pattern=r"\b(apply|exact)\?")
         assert count == 0
 
-    def test_default_pattern_does_not_match_axiom(self):
-        """Default pattern only matches sorry/admit, not axiom."""
+    def test_sorry_pattern_does_not_match_axiom(self):
+        """Sorry/admit pattern does not match axiom."""
         code = "axiom myAxiom : Nat → Nat"
-        count, _ = count_sorries(code)
+        count, _ = count_pattern(code, pattern=self.SORRY_PATTERN)
         assert count == 0
 
 

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -192,6 +192,31 @@ class TestCountSorries:
         count, _ = count_sorries(code)
         assert count == 0
 
+    def test_custom_pattern_detects_axiom(self):
+        """Custom pattern detects axiom declarations."""
+        code = "axiom myAxiom : Nat → Nat\ntheorem foo : True := trivial"
+        count, locations = count_sorries(code, pattern=r"\baxiom\b")
+        assert count == 1
+        assert locations[0][0] == 1
+
+    def test_custom_pattern_detects_search_tactics(self):
+        """Custom pattern detects apply? and exact?."""
+        code = "theorem foo : P := by\n  apply?\n  exact?"
+        count, _ = count_sorries(code, pattern=r"\b(apply|exact)\?")
+        assert count == 2
+
+    def test_custom_pattern_does_not_flag_apply_without_question_mark(self):
+        """apply (without ?) is not flagged by the search tactics pattern."""
+        code = "theorem foo : P := by\n  apply some_lemma"
+        count, _ = count_sorries(code, pattern=r"\b(apply|exact)\?")
+        assert count == 0
+
+    def test_default_pattern_does_not_match_axiom(self):
+        """Default pattern only matches sorry/admit, not axiom."""
+        code = "axiom myAxiom : Nat → Nat"
+        count, _ = count_sorries(code)
+        assert count == 0
+
 
 class TestExtractFunctionFromContent:
     """Tests for extract_function_from_content function."""

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 ]
 
 [[package]]
-name = "ax-agent"
+name = "ax-prover"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -196,11 +196,11 @@ dependencies = [
     { name = "langgraph" },
     { name = "lean-interact" },
     { name = "omegaconf" },
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pylatexenc" },
     { name = "python-dotenv" },
     { name = "requests" },
-    { name = "setuptools-scm" },
     { name = "tavily-python" },
     { name = "wikipedia" },
 ]
@@ -214,6 +214,8 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "setuptools-scm" },
+    { name = "twine" },
 ]
 
 [package.metadata]
@@ -229,6 +231,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.3" },
     { name = "lean-interact", specifier = ">=0.1.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
+    { name = "platformdirs", specifier = ">=4.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pylatexenc", specifier = ">=2.10" },
@@ -239,11 +242,21 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.6" },
-    { name = "setuptools-scm", specifier = ">=9.2.2" },
+    { name = "setuptools-scm", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "tavily-python", specifier = ">=0.7.13" },
+    { name = "twine", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "wikipedia", specifier = ">=1.4.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
 
 [[package]]
 name = "beautifulsoup4"
@@ -633,6 +646,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
@@ -857,6 +879,18 @@ wheels = [
 ]
 
 [[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -875,12 +909,69 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1004,6 +1095,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1199,6 +1308,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1313,6 +1431,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/37/ab55eb2b05e334ff9a1ad52c556ace1f9c20a3f63613a165d384d5387657/nh3-0.3.3.tar.gz", hash = "sha256:185ed41b88c910b9ca8edc89ca3b4be688a12cb9de129d84befa2f74a0039fee", size = 18968, upload-time = "2026-02-14T09:35:15.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/a4/834f0ebd80844ce67e1bdb011d6f844f61cdb4c1d7cdc56a982bc054cc00/nh3-0.3.3-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:21b058cd20d9f0919421a820a2843fdb5e1749c0bf57a6247ab8f4ba6723c9fc", size = 1428680, upload-time = "2026-02-14T09:34:33.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1a/a7d72e750f74c6b71befbeebc4489579fe783466889d41f32e34acde0b6b/nh3-0.3.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4400a73c2a62859e769f9d36d1b5a7a5c65c4179d1dddd2f6f3095b2db0cbfc", size = 799003, upload-time = "2026-02-14T09:34:35.108Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/089eb6d65da139dc2223b83b2627e00872eccb5e1afdf5b1d76eb6ad3fcc/nh3-0.3.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1ef87f8e916321a88b45f2d597f29bd56e560ed4568a50f0f1305afab86b7189", size = 846818, upload-time = "2026-02-14T09:34:37Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c6/44a0b65fc7b213a3a725f041ef986534b100e58cd1a2e00f0fd3c9603893/nh3-0.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a446eae598987f49ee97ac2f18eafcce4e62e7574bd1eb23782e4702e54e217d", size = 1012537, upload-time = "2026-02-14T09:34:38.515Z" },
+    { url = "https://files.pythonhosted.org/packages/94/3a/91bcfcc0a61b286b8b25d39e288b9c0ba91c3290d402867d1cd705169844/nh3-0.3.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0d5eb734a78ac364af1797fef718340a373f626a9ff6b4fb0b4badf7927e7b81", size = 1095435, upload-time = "2026-02-14T09:34:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fd/4617a19d80cf9f958e65724ff5e97bc2f76f2f4c5194c740016606c87bd1/nh3-0.3.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:92a958e6f6d0100e025a5686aafd67e3c98eac67495728f8bb64fbeb3e474493", size = 1056344, upload-time = "2026-02-14T09:34:41.469Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7d/5bcbbc56e71b7dda7ef1d6008098da9c5426d6334137ef32bb2b9c496984/nh3-0.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9ed40cf8449a59a03aa465114fedce1ff7ac52561688811d047917cc878b19ca", size = 1034533, upload-time = "2026-02-14T09:34:43.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/9c/054eff8a59a8b23b37f0f4ac84cdd688ee84cf5251664c0e14e5d30a8a67/nh3-0.3.3-cp314-cp314t-win32.whl", hash = "sha256:b50c3770299fb2a7c1113751501e8878d525d15160a4c05194d7fe62b758aad8", size = 608305, upload-time = "2026-02-14T09:34:44.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b0/64667b8d522c7b859717a02b1a66ba03b529ca1df623964e598af8db1ed5/nh3-0.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:21a63ccb18ddad3f784bb775955839b8b80e347e597726f01e43ca1abcc5c808", size = 620633, upload-time = "2026-02-14T09:34:46.069Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b5/ae9909e4ddfd86ee076c4d6d62ba69e9b31061da9d2f722936c52df8d556/nh3-0.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f508ddd4e2433fdcb78c790fc2d24e3a349ba775e5fa904af89891321d4844a3", size = 607027, upload-time = "2026-02-14T09:34:47.91Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/aef8cf8e0419b530c95e96ae93a5078e9b36c1e6613eeb1df03a80d5194e/nh3-0.3.3-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e8ee96156f7dfc6e30ecda650e480c5ae0a7d38f0c6fafc3c1c655e2500421d9", size = 1448640, upload-time = "2026-02-14T09:34:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/43/d2011a4f6c0272cb122eeff40062ee06bb2b6e57eabc3a5e057df0d582df/nh3-0.3.3-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45fe0d6a607264910daec30360c8a3b5b1500fd832d21b2da608256287bcb92d", size = 839405, upload-time = "2026-02-14T09:34:50.779Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f3/965048510c1caf2a34ed04411a46a04a06eb05563cd06f1aa57b71eb2bc8/nh3-0.3.3-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5bc1d4b30ba1ba896669d944b6003630592665974bd11a3dc2f661bde92798a7", size = 825849, upload-time = "2026-02-14T09:34:52.622Z" },
+    { url = "https://files.pythonhosted.org/packages/78/99/b4bbc6ad16329d8db2c2c320423f00b549ca3b129c2b2f9136be2606dbb0/nh3-0.3.3-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f433a2dd66545aad4a720ad1b2150edcdca75bfff6f4e6f378ade1ec138d5e77", size = 1068303, upload-time = "2026-02-14T09:34:54.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/34/3420d97065aab1b35f3e93ce9c96c8ebd423ce86fe84dee3126790421a2a/nh3-0.3.3-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52e973cb742e95b9ae1b35822ce23992428750f4b46b619fe86eba4205255b30", size = 1029316, upload-time = "2026-02-14T09:34:56.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9a/99eda757b14e596fdb2ca5f599a849d9554181aa899274d0d183faef4493/nh3-0.3.3-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c730617bdc15d7092dcc0469dc2826b914c8f874996d105b4bc3842a41c1cd9", size = 919944, upload-time = "2026-02-14T09:34:57.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/84/c0dc75c7fb596135f999e59a410d9f45bdabb989f1cb911f0016d22b747b/nh3-0.3.3-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e98fa3dbfd54e25487e36ba500bc29bca3a4cab4ffba18cfb1a35a2d02624297", size = 811461, upload-time = "2026-02-14T09:34:59.65Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ec/b1bf57cab6230eec910e4863528dc51dcf21b57aaf7c88ee9190d62c9185/nh3-0.3.3-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:3a62b8ae7c235481715055222e54c682422d0495a5c73326807d4e44c5d14691", size = 840360, upload-time = "2026-02-14T09:35:01.444Z" },
+    { url = "https://files.pythonhosted.org/packages/37/5e/326ae34e904dde09af1de51219a611ae914111f0970f2f111f4f0188f57e/nh3-0.3.3-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc305a2264868ec8fa16548296f803d8fd9c1fa66cd28b88b605b1bd06667c0b", size = 859872, upload-time = "2026-02-14T09:35:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/09/38/7eba529ce17ab4d3790205da37deabb4cb6edcba15f27b8562e467f2fc97/nh3-0.3.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:90126a834c18af03bfd6ff9a027bfa6bbf0e238527bc780a24de6bd7cc1041e2", size = 1023550, upload-time = "2026-02-14T09:35:04.829Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a2/556fdecd37c3681b1edee2cf795a6799c6ed0a5551b2822636960d7e7651/nh3-0.3.3-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24769a428e9e971e4ccfb24628f83aaa7dc3c8b41b130c8ddc1835fa1c924489", size = 1105212, upload-time = "2026-02-14T09:35:06.821Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e3/5db0b0ad663234967d83702277094687baf7c498831a2d3ad3451c11770f/nh3-0.3.3-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:b7a18ee057761e455d58b9d31445c3e4b2594cff4ddb84d2e331c011ef46f462", size = 1069970, upload-time = "2026-02-14T09:35:08.504Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b2/2ea21b79c6e869581ce5f51549b6e185c4762233591455bf2a326fb07f3b/nh3-0.3.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5a4b2c1f3e6f3cbe7048e17f4fefad3f8d3e14cc0fd08fb8599e0d5653f6b181", size = 1047588, upload-time = "2026-02-14T09:35:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/92/2e434619e658c806d9c096eed2cdff9a883084299b7b19a3f0824eb8e63d/nh3-0.3.3-cp38-abi3-win32.whl", hash = "sha256:e974850b131fdffa75e7ad8e0d9c7a855b96227b093417fdf1bd61656e530f37", size = 616179, upload-time = "2026-02-14T09:35:11.366Z" },
+    { url = "https://files.pythonhosted.org/packages/73/88/1ce287ef8649dc51365b5094bd3713b76454838140a32ab4f8349973883c/nh3-0.3.3-cp38-abi3-win_amd64.whl", hash = "sha256:2efd17c0355d04d39e6d79122b42662277ac10a17ea48831d90b46e5ef7e4fc0", size = 631159, upload-time = "2026-02-14T09:35:12.77Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f1/b4835dbde4fb06f29db89db027576d6014081cd278d9b6751facc3e69e43/nh3-0.3.3-cp38-abi3-win_arm64.whl", hash = "sha256:b838e619f483531483d26d889438e53a880510e832d2aafe73f93b7b1ac2bce2", size = 616645, upload-time = "2026-02-14T09:35:14.062Z" },
 ]
 
 [[package]]
@@ -1873,6 +2025,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1925,6 +2086,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "readme-renderer"
+version = "44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
 ]
 
 [[package]]
@@ -2059,6 +2234,15 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2106,6 +2290,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
     { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
     { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2298,6 +2495,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "twine"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "id" },
+    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
 ]
 
 [[package]]
@@ -2636,6 +2853,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
   
  - The builder node now rejects proposals that introduce axiom declarations or contain search tactics (apply?,
  exact?) — previously only sorry/admit were caught programmatically
  - count_sorries() accepts a custom pattern parameter so the same matching logic is reused for all forbidden
  patterns
  - Checks run on comment-stripped code to avoid false positives from comments
  - Two new feedback types (AxiomDetectedFeedback, SearchTacticsDetectedFeedback) give the LLM clear instructions
  on what to fix

  Test plan
  - New unit tests for custom pattern matching (axiom, search tactics, no false positives on apply without ?)
  - Existing tests pass unchanged