### PR TITLE
Support Claude 4.6

### DIFF
--- a/configs/llms.yaml
+++ b/configs/llms.yaml
@@ -14,11 +14,18 @@ llm_configs:
     provider_config:
       temperature: 1.0 # Must be set to 1.0 for thinking
       max_tokens: null
-      betas:
-        - "structured-outputs-2025-11-13"
+      effort: "medium"  # "low", "medium", "high" (default), "max"
       thinking:
-        type: "enabled"
-        budget_tokens: 10000
+        type: "adaptive"
+
+  claude_sonnet_4_6:
+    model: "anthropic:claude-sonnet-4-6"
+    provider_config:
+      temperature: 1.0 # Must be set to 1.0 for thinking
+      max_tokens: null
+      effort: "medium"  
+      thinking:
+        type: "adaptive"
 
   claude_opus_4_5:
     model: "anthropic:claude-opus-4-5"

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -285,7 +285,7 @@ class ProverAgent:
             HumanMessage(content=query),
         ]
 
-        response, _ = await agentic_loop(
+        response = await agentic_loop(
             self.llm_client,
             context_messages,
             tools=self.proposer_tools,

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -3,10 +3,8 @@
 from asyncio import Semaphore
 from collections.abc import Sequence
 
-from langchain_core.language_models import LanguageModelInput
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
-from langchain_core.runnables.retry import RunnableRetry
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
@@ -49,12 +47,7 @@ from ..utils.lean_parsing import (
     find_declaration_by_name,
     list_all_declarations_in_lean_code,
 )
-from ..utils.llm import (
-    ainvoke_retry_with_structured_output,
-    create_llm,
-    get_reasoning,
-    run_tools_and_respond,
-)
+from ..utils.llm import LLMClient, agentic_loop, get_reasoning
 from . import memory as memory_module
 from .memory import BaseMemory
 from .prompts import (
@@ -75,7 +68,7 @@ class ProverAgent:
     A Lean4 theorem prover
     """
 
-    llm: RunnableRetry
+    llm_client: LLMClient
     memory: BaseMemory
     app: CompiledStateGraph
 
@@ -97,19 +90,15 @@ class ProverAgent:
 
         self.proposer_tools = []
 
-        self.llm = create_llm(self.config.prover_llm).with_retry(
-            **self.config.prover_llm.retry_config
-        )
+        self.llm_client = LLMClient(self.config.prover_llm)
 
         memory_class = getattr(memory_module, self.config.memory_config.class_name)
         self.memory = memory_class(**self.config.memory_config.init_args)
 
         summary_llm_config = self.config.summarize_output.llm or self.config.prover_llm
-        self.summary_llm = create_llm(summary_llm_config).with_retry(
-            **summary_llm_config.retry_config
-        )
+        self.summary_llm_client = LLMClient(summary_llm_config)
 
-        self.max_input_tokens = self.llm.bound.profile.get("max_input_tokens")
+        self.max_input_tokens = self.llm_client.profile.get("max_input_tokens")
         if self.max_input_tokens < 1000:
             self.logger.error("Error: max_input_tokens abnormally small")
 
@@ -293,37 +282,13 @@ class ProverAgent:
             HumanMessage(content=query),
         ]
 
-        llm_with_tools_retry = self.llm.bound.bind_tools(self.proposer_tools).with_retry(
-            **self.config.prover_llm.retry_config
+        response, _ = await agentic_loop(
+            self.llm_client,
+            context_messages,
+            tools=self.proposer_tools,
+            output_schema=ProverResult,
+            max_tool_iterations=self.runtime_config.max_tool_calling_iterations,
         )
-
-        async def proposer_agent(msg: LanguageModelInput, llm: RunnableRetry):
-            return await ainvoke_retry_with_structured_output(msg, llm, ProverResult)
-
-        response = await proposer_agent(context_messages, llm_with_tools_retry)
-        all_new_messages = [response]
-
-        for iteration in range(self.runtime_config.max_tool_calling_iterations):
-            if not response.tool_calls:
-                break
-
-            if iteration == self.runtime_config.max_tool_calling_iterations - 1:
-                llm = self.llm
-                extra_message = "NO MORE TOOL CALLS ALLOWED."  # Prevent hallucinated tool calls
-            else:
-                llm = llm_with_tools_retry
-                extra_message = None
-
-            new_msgs = await run_tools_and_respond(
-                response,
-                self.proposer_tools,
-                context_messages + all_new_messages[:-1],
-                proposer_agent,
-                llm,
-                extra_message,
-            )
-            response = new_msgs[-1]
-            all_new_messages += new_msgs
 
         try:
             result = ProverResult.model_validate_json(response.text)
@@ -447,7 +412,7 @@ class ProverAgent:
             HumanMessage(content=query),
         ]
 
-        response = await ainvoke_retry_with_structured_output(messages, self.llm, ReviewDecision)
+        response = await self.llm_client.ainvoke(messages, output_schema=ReviewDecision)
         try:
             review_result = ReviewDecision.model_validate_json(response.text)
         except Exception as e:
@@ -535,7 +500,7 @@ class ProverAgent:
             experience=state.experience or "No experience recorded",
         )
 
-        response = await self.summary_llm.ainvoke(
+        response = await self.summary_llm_client.ainvoke(
             [
                 SystemMessage(content=SUMMARIZE_OUTPUT_SYSTEM_PROMPT),
                 HumanMessage(content=query),

--- a/src/ax_prover/prover/memory.py
+++ b/src/ax_prover/prover/memory.py
@@ -3,24 +3,23 @@
 from abc import ABC, abstractmethod
 
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_core.runnables.retry import RunnableRetry
 
 from ..config import LLMConfig
 from ..models import ProverAgentState
 from ..models.messages import FeedbackMessage, ProposalMessage
 from ..utils import get_logger
-from ..utils.llm import create_llm
+from ..utils.llm import LLMClient
 from .prompts import ATTEMPT_TEMPLATE
 
 
 class BaseMemory(ABC):
     """Base class for prover memory processing strategies."""
 
-    llm: RunnableRetry | None = None
+    llm: LLMClient | None = None
 
     def __init__(self, llm_config: LLMConfig | None = None):
         if llm_config:
-            self.llm = create_llm(LLMConfig(**llm_config))
+            self.llm = LLMClient(LLMConfig(**llm_config))
 
         self.logger = get_logger(__name__)
 

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -1,7 +1,6 @@
 """LLM factory functions."""
 
 import os
-from collections.abc import Awaitable, Callable
 
 from anthropic import transform_schema
 from langchain.chat_models import init_chat_model
@@ -10,7 +9,6 @@ from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.runnables import Runnable
-from langchain_core.runnables.retry import RunnableRetry
 from langchain_core.tools import BaseTool
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
@@ -39,79 +37,50 @@ def create_llm(config: LLMConfig) -> BaseChatModel:
     )
 
 
-async def ainvoke_retry_with_structured_output(
-    messages: LanguageModelInput, llm: RunnableRetry, schema: BaseModel
-):
-    "Invoke an LLM with retry enforcing native structured output for each provider."
-    chat_model = _get_base_chat_model_from_binding(llm)
-
-    # LANGCHAIN PLS ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS
-    if isinstance(chat_model, ChatAnthropic):
-        return await llm.ainvoke(
-            messages, output_format={"type": "json_schema", "schema": transform_schema(schema)}
-        )
-
-    if isinstance(chat_model, ChatGoogleGenerativeAI):
-        return await llm.ainvoke(
-            messages,
-            response_mime_type="application/json",
-            response_json_schema=schema.model_json_schema(),
-        )
-
-    if isinstance(chat_model, ChatOpenAI):
-        # For Qwen we will have to check the chat_model.openai_api_base (may be None for openai)
-        return await llm.ainvoke(messages, response_format=schema)
-
-    return await chat_model.with_structured_output(schema).with_retry().ainvoke(messages)
-
-
-def _get_base_chat_model_from_binding(llm: RunnableRetry) -> BaseChatModel:
-    """
-    Iteratively find the unwrapped base chat model in a potentially nested binding of Runnable/Bound objects.
-    Stops at the lowest-level model (e.g., ChatAnthropic, ChatGoogleGenerativeAI, etc.).
-    """
-    chat_model = llm
-
-    while hasattr(chat_model, "bound"):
-        if chat_model is chat_model.bound:
-            break  # Prevent infinite recursion if .bound returns self
-        chat_model = chat_model.bound
-
-    return chat_model
-
-
-async def run_tools_and_respond(
-    response: AIMessage,
-    tools: list[BaseTool],
+async def agentic_loop(
+    client: "LLMClient",
     messages: list[BaseMessage],
-    invoke_function_async: Callable[[LanguageModelInput, RunnableRetry], Awaitable[BaseMessage]],
-    llm: RunnableRetry,
-    extra_message: str | None = None,
-) -> list[BaseMessage]:
-    """Execute pending tool calls from a given response and invoke the llm to get the next response
-    using the provided function.
+    tools: list[BaseTool],
+    output_schema: type[BaseModel] | None = None,
+    max_tool_iterations: int = 5,
+) -> tuple[AIMessage, list[BaseMessage]]:
+    """Invoke an LLM with tools, executing tool calls in a loop until the model stops calling tools.
 
-    Args:
-        response: The response from the LLM that may contain tool calls
-        tools: The tools to execute
-        messages: The history of messages in the conversation prior to the response
-        invoke_function_async: The function to invoke an LLM with a given messages and LLM
-        llm: The LLM to call to get the next response after the tool calls have been executed
-        extra_message: An optional extra message to add to the messages
+    On the last allowed iteration the tools are dropped and a "NO MORE TOOL CALLS ALLOWED."
+    message is injected so the model produces a final text/structured response.
 
     Returns:
-        A list of messages including the new response after the tool calls have been executed"""
+        A tuple of (final_response, all_new_messages) where all_new_messages includes every
+        intermediate AI message, tool result, and the final response.
+    """
+    response = await client.ainvoke(messages, tools=tools, output_schema=output_schema)
+    all_new_messages: list[BaseMessage] = [response]
 
     tool_node = ToolNode(tools)
-    result = await tool_node.ainvoke({"messages": messages + [response]})
-    new_messages = result["messages"]
 
-    invoke_messages = messages + [response] + new_messages
-    if extra_message:
-        invoke_messages = invoke_messages + [HumanMessage(content=extra_message)]
+    for iteration in range(max_tool_iterations):
+        if not response.tool_calls:
+            break
 
-    new_response = await invoke_function_async(invoke_messages, llm)
-    return new_messages + [new_response]
+        result = await tool_node.ainvoke({"messages": messages + all_new_messages})
+        tool_messages = result["messages"]
+        all_new_messages += tool_messages
+
+        is_last_iteration = iteration == max_tool_iterations - 1
+        invoke_messages = messages + all_new_messages
+        if is_last_iteration:
+            invoke_messages = invoke_messages + [
+                HumanMessage(content="NO MORE TOOL CALLS ALLOWED.")
+            ]
+            response = await client.ainvoke(invoke_messages, output_schema=output_schema)
+        else:
+            response = await client.ainvoke(
+                invoke_messages, tools=tools, output_schema=output_schema
+            )
+
+        all_new_messages.append(response)
+
+    return response, all_new_messages
 
 
 def get_reasoning(response: AIMessage) -> str:

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -78,7 +78,7 @@ async def agentic_loop(
 
         new_messages.append(response)
 
-    return response, new_messages
+    return response
 
 
 def get_reasoning(response: AIMessage) -> str:

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -9,6 +9,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.runnables import Runnable
 from langchain_core.runnables.retry import RunnableRetry
 from langchain_core.tools import BaseTool
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -44,6 +45,7 @@ async def ainvoke_retry_with_structured_output(
     "Invoke an LLM with retry enforcing native structured output for each provider."
     chat_model = _get_base_chat_model_from_binding(llm)
 
+    # LANGCHAIN PLS ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS
     if isinstance(chat_model, ChatAnthropic):
         return await llm.ainvoke(
             messages, output_format={"type": "json_schema", "schema": transform_schema(schema)}
@@ -118,3 +120,123 @@ def get_reasoning(response: AIMessage) -> str:
         [msg.get("reasoning", "") for msg in response.content_blocks if msg["type"] == "reasoning"]
     )
     return reasoning
+
+
+class LLMClient:
+    """Dynamically create a retryable Runnable that handles structured output and tool calling.
+
+    Usage:
+        client = LLMClient(config)
+
+        # Plain call
+        response = await client.ainvoke(messages)
+
+        # With tools only
+        response = await client.ainvoke(messages, tools=my_tools)
+
+        # With structured output only (returns AIMessage with JSON .text)
+        response = await client.ainvoke(messages, output_schema=MyModel)
+
+        # With both tools and structured output
+        response = await client.ainvoke(messages, tools=my_tools, output_schema=MyModel)
+
+        # Pre-build a runnable for repeated use in a loop
+        runnable = client.get_runnable(tools=my_tools, output_schema=MyModel)
+        response = await runnable.ainvoke(messages)
+    """
+
+    def __init__(self, config: LLMConfig):
+        """Initialize the LLMClient with a configuration."""
+        self._base_llm: BaseChatModel = create_llm(config)
+        self._retry_config: dict = config.retry_config
+
+    async def ainvoke(
+        self,
+        messages: LanguageModelInput,
+        tools: list[BaseTool] | None = None,
+        output_schema: BaseModel | None = None,
+        retry_config: dict | None = None,
+    ) -> AIMessage:
+        """Invoke with optional tools, structured output, and retry."""
+        runnable = self._get_runnable(
+            tools=tools, output_schema=output_schema, retry_config=retry_config
+        )
+        return await runnable.ainvoke(messages)
+
+    def _get_runnable(
+        self,
+        tools: list[BaseTool] | None = None,
+        output_schema: BaseModel | None = None,
+        retry_config: dict | None = None,
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        """Build a retryable Runnable that always returns AIMessage.
+
+        Layers are applied in order: bind_tools → bind structured output → with_retry.
+        """
+        model: Runnable = self._base_llm
+
+        if tools:
+            model = self._base_llm.bind_tools(tools)
+
+        if output_schema:
+            model = model.bind(**self._structured_output_bind_kwargs(output_schema))
+
+        retry_config = retry_config or self._retry_config
+        if retry_config:
+            model = model.with_retry(**retry_config)
+
+        return model
+
+    def _structured_output_bind_kwargs(self, schema: BaseModel) -> dict:
+        """Return provider-specific kwargs that constrain the output to a JSON schema.
+
+        These kwargs are passed via bind() so the response stays as an AIMessage, unlike
+        `with_structured_output`, which prevents the use of any tools and forces the output
+        to be an instance of the schema.
+        """
+        # LANGCHAIN ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS PLSSS
+        json_schema = schema.model_json_schema()
+
+        if isinstance(self._base_llm, ChatAnthropic):
+            model_name = getattr(self._base_llm, "model", "")  # Need to check 4.5 or 4.6+
+            return _anthropic_structured_kwargs(model_name, json_schema)
+
+        if isinstance(self._base_llm, ChatGoogleGenerativeAI):
+            return _google_structured_kwargs(json_schema)
+
+        if isinstance(self._base_llm, ChatOpenAI):
+            return _openai_structured_kwargs(json_schema)
+
+        raise NotImplementedError(
+            f"Structured output bind kwargs not implemented for {type(self._base_llm).__name__}."
+        )
+
+
+def _anthropic_structured_kwargs(model_name: str, json_schema: dict) -> dict:
+    is_46 = "4-6" in model_name or "4.6" in model_name
+
+    schema_payload = {"type": "json_schema", "schema": transform_schema(json_schema)}
+
+    if is_46:
+        # Claude 4.6+: output_config.format (output_format is deprecated)
+        return {"output_config": {"format": schema_payload}}
+    else:
+        # Claude 4.5 and earlier: output_format
+        return {"output_format": schema_payload}
+
+
+def _openai_structured_kwargs(json_schema: dict) -> dict:
+    return {
+        "response_format": {
+            "type": "json_schema",
+            "strict": True,
+            "schema": json_schema,
+        }
+    }
+
+
+def _google_structured_kwargs(json_schema: dict) -> dict:
+    return {
+        "response_mime_type": "application/json",
+        "response_json_schema": json_schema,
+    }

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -122,13 +122,19 @@ def get_reasoning(response: AIMessage) -> str:
     return reasoning
 
 
+_UNSET = object()
+
+
 class LLMClient:
     """Dynamically create a Runnable to invoke LLMs with structured output, tool calling and retry.
+
+    Retry is applied by default using the config's retry_config. Pass retry_config=None
+    to disable, or pass a custom dict to override.
 
     Usage:
         client = LLMClient(config)
 
-        # Plain call
+        # Plain call (uses default retry from config)
         response = await client.ainvoke(messages)
 
         # With tools only
@@ -137,30 +143,38 @@ class LLMClient:
         # With structured output only
         response = await client.ainvoke(messages, output_schema=MyModel)
 
-        # With retry only
-        response = await client.ainvoke(messages, retry_config=retry_config)
 
         # With tools and structured output
         response = await client.ainvoke(messages, tools=my_tools, output_schema=MyModel)
 
-        # With tools, structured output and retry
-        response = await client.ainvoke(messages, tools=my_tools, output_schema=MyModel, retry_config=retry_config)
+        # Override retry
+        response = await client.ainvoke(messages, retry_config={"stop_after_attempt": 3})
+
+        # Disable retry
+        response = await client.ainvoke(messages, retry_config=None)
     """
 
     def __init__(self, config: LLMConfig):
         """Initialize the LLMClient with a configuration."""
         self._base_llm: BaseChatModel = create_llm(config)
+        self._retry_config: dict | None = config.retry_config or None
+
+    @property
+    def profile(self) -> dict:
+        """Model metadata (max_input_tokens, max_output_tokens, capabilities, etc.)."""
+        return getattr(self._base_llm, "profile", {})
 
     async def ainvoke(
         self,
         messages: LanguageModelInput,
         tools: list[BaseTool] | None = None,
         output_schema: BaseModel | None = None,
-        retry_config: dict | None = None,
+        retry_config: dict | None | object = _UNSET,
     ) -> AIMessage:
         """Invoke with optional tools, structured output, and retry."""
+        effective_retry = self._retry_config if retry_config is _UNSET else retry_config
         runnable = self._get_runnable(
-            tools=tools, output_schema=output_schema, retry_config=retry_config
+            tools=tools, output_schema=output_schema, retry_config=effective_retry
         )
         return await runnable.ainvoke(messages)
 

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -89,9 +89,6 @@ def get_reasoning(response: AIMessage) -> str:
     return reasoning
 
 
-_UNSET = object()
-
-
 class LLMClient:
     """Dynamically create a Runnable to invoke LLMs with structured output, tool calling and retry.
 
@@ -115,15 +112,12 @@ class LLMClient:
 
         # Override retry
         response = await client.ainvoke(messages, retry_config={"stop_after_attempt": 3})
-
-        # Disable retry
-        response = await client.ainvoke(messages, retry_config=None)
     """
 
     def __init__(self, config: LLMConfig):
         """Initialize the LLMClient with a configuration."""
         self._base_llm: BaseChatModel = create_llm(config)
-        self._retry_config: dict | None = config.retry_config or None
+        self._retry_config: dict = config.retry_config
 
     @property
     def profile(self) -> dict:
@@ -135,10 +129,10 @@ class LLMClient:
         messages: LanguageModelInput,
         tools: list[BaseTool] | None = None,
         output_schema: type[BaseModel] | None = None,
-        retry_config: dict | None | object = _UNSET,
+        retry_config: dict | None = None,
     ) -> AIMessage:
         """Invoke with optional tools, structured output, and retry."""
-        effective_retry = self._retry_config if retry_config is _UNSET else retry_config
+        effective_retry = retry_config or self._retry_config
         runnable = self._get_runnable(
             tools=tools, output_schema=output_schema, retry_config=effective_retry
         )

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -51,7 +51,7 @@ async def agentic_loop(
         intermediate AI message, tool result, and the final response.
     """
     response = await client.ainvoke(messages, tools=tools, output_schema=output_schema)
-    all_new_messages: list[BaseMessage] = [response]
+    new_messages: list[BaseMessage] = [response]
 
     tool_node = ToolNode(tools)
 
@@ -59,12 +59,12 @@ async def agentic_loop(
         if not response.tool_calls:
             break
 
-        result = await tool_node.ainvoke({"messages": messages + all_new_messages})
+        result = await tool_node.ainvoke({"messages": messages + new_messages})
         tool_messages = result["messages"]
-        all_new_messages += tool_messages
+        new_messages += tool_messages
 
         is_last_iteration = iteration == max_tool_iterations - 1
-        invoke_messages = messages + all_new_messages
+        invoke_messages = messages + new_messages
         if is_last_iteration:
             # Prevent hallucinated tool calls with this message
             invoke_messages = invoke_messages + [
@@ -76,9 +76,9 @@ async def agentic_loop(
                 invoke_messages, tools=tools, output_schema=output_schema
             )
 
-        all_new_messages.append(response)
+        new_messages.append(response)
 
-    return response, all_new_messages
+    return response, new_messages
 
 
 def get_reasoning(response: AIMessage) -> str:
@@ -109,7 +109,6 @@ class LLMClient:
 
         # With structured output only
         response = await client.ainvoke(messages, output_schema=MyModel)
-
 
         # With tools and structured output
         response = await client.ainvoke(messages, tools=my_tools, output_schema=MyModel)

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -195,27 +195,29 @@ class LLMClient:
         to be an instance of the schema.
         """
         # LANGCHAIN ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS PLSSS
-        json_schema = schema.model_json_schema()
 
         if isinstance(self._base_llm, ChatAnthropic):
             model_name = getattr(self._base_llm, "model", "")  # Need to check 4.5 or 4.6+
-            return _anthropic_structured_kwargs(model_name, json_schema)
+            return _anthropic_structured_kwargs(model_name, schema)
 
         if isinstance(self._base_llm, ChatGoogleGenerativeAI):
-            return _google_structured_kwargs(json_schema)
+            return _google_structured_kwargs(schema.model_json_schema())
 
         if isinstance(self._base_llm, ChatOpenAI):
-            return _openai_structured_kwargs(json_schema)
+            return _openai_structured_kwargs(schema)
 
         raise NotImplementedError(
             f"Structured output bind kwargs not implemented for {type(self._base_llm).__name__}."
         )
 
 
-def _anthropic_structured_kwargs(model_name: str, json_schema: dict) -> dict:
+def _anthropic_structured_kwargs(model_name: str, schema: BaseModel) -> dict:
+    json_schema = schema.model_json_schema()
+    json_schema = transform_schema(json_schema)
+
     is_46 = "4-6" in model_name or "4.6" in model_name
 
-    schema_payload = {"type": "json_schema", "schema": transform_schema(json_schema)}
+    schema_payload = {"type": "json_schema", "schema": json_schema}
 
     if is_46:
         # Claude 4.6+: output_config.format (output_format is deprecated)
@@ -225,18 +227,14 @@ def _anthropic_structured_kwargs(model_name: str, json_schema: dict) -> dict:
         return {"output_format": schema_payload}
 
 
-def _openai_structured_kwargs(json_schema: dict) -> dict:
-    return {
-        "response_format": {
-            "type": "json_schema",
-            "strict": True,
-            "schema": json_schema,
-        }
-    }
+def _google_structured_kwargs(schema: BaseModel) -> dict:
+    json_schema = schema.model_json_schema()
 
-
-def _google_structured_kwargs(json_schema: dict) -> dict:
     return {
         "response_mime_type": "application/json",
         "response_json_schema": json_schema,
     }
+
+
+def _openai_structured_kwargs(schema: BaseModel) -> dict:
+    return {"response_format": schema}

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -46,9 +46,6 @@ async def agentic_loop(
 ) -> tuple[AIMessage, list[BaseMessage]]:
     """Invoke an LLM with tools, executing tool calls in a loop until the model stops calling tools.
 
-    On the last allowed iteration the tools are dropped and a "NO MORE TOOL CALLS ALLOWED."
-    message is injected so the model produces a final text/structured response.
-
     Returns:
         A tuple of (final_response, all_new_messages) where all_new_messages includes every
         intermediate AI message, tool result, and the final response.
@@ -69,6 +66,7 @@ async def agentic_loop(
         is_last_iteration = iteration == max_tool_iterations - 1
         invoke_messages = messages + all_new_messages
         if is_last_iteration:
+            # Prevent hallucinated tool calls with this message
             invoke_messages = invoke_messages + [
                 HumanMessage(content="NO MORE TOOL CALLS ALLOWED.")
             ]

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -135,7 +135,7 @@ class LLMClient:
         self,
         messages: LanguageModelInput,
         tools: list[BaseTool] | None = None,
-        output_schema: BaseModel | None = None,
+        output_schema: type[BaseModel] | None = None,
         retry_config: dict | None | object = _UNSET,
     ) -> AIMessage:
         """Invoke with optional tools, structured output, and retry."""
@@ -148,7 +148,7 @@ class LLMClient:
     def _get_runnable(
         self,
         tools: list[BaseTool] | None = None,
-        output_schema: BaseModel | None = None,
+        output_schema: type[BaseModel] | None = None,
         retry_config: dict | None = None,
     ) -> Runnable[LanguageModelInput, AIMessage]:
         """Build a retryable Runnable that always returns AIMessage.
@@ -171,7 +171,7 @@ class LLMClient:
 
         return model
 
-    def _structured_output_bind_kwargs(self, schema: BaseModel) -> dict:
+    def _structured_output_bind_kwargs(self, schema: type[BaseModel]) -> dict:
         """Return provider-specific kwargs that constrain the output to a JSON schema.
 
         These kwargs are passed via bind() so the response stays as an AIMessage, unlike
@@ -195,7 +195,7 @@ class LLMClient:
         )
 
 
-def _anthropic_structured_kwargs(model_name: str, schema: BaseModel) -> dict:
+def _anthropic_structured_kwargs(model_name: str, schema: type[BaseModel]) -> dict:
     json_schema = schema.model_json_schema()
     json_schema = transform_schema(json_schema)
 
@@ -211,7 +211,7 @@ def _anthropic_structured_kwargs(model_name: str, schema: BaseModel) -> dict:
         return {"output_format": schema_payload}
 
 
-def _google_structured_kwargs(schema: BaseModel) -> dict:
+def _google_structured_kwargs(schema: type[BaseModel]) -> dict:
     json_schema = schema.model_json_schema()
 
     return {
@@ -220,5 +220,5 @@ def _google_structured_kwargs(schema: BaseModel) -> dict:
     }
 
 
-def _openai_structured_kwargs(schema: BaseModel) -> dict:
+def _openai_structured_kwargs(schema: type[BaseModel]) -> dict:
     return {"response_format": schema}

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -177,7 +177,8 @@ class LLMClient:
         `with_structured_output`, which prevents the use of any tools and forces the output
         to be an instance of the schema.
         """
-        # LANGCHAIN ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS PLSSS
+        # LANGCHAIN PLSSS ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS
+        # LOOK AT WHAT IT NEED TO DO C'MONNNNN
 
         if isinstance(self._base_llm, ChatAnthropic):
             model_name = getattr(self._base_llm, "model", "")  # Need to check 4.5 or 4.6+

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -123,7 +123,7 @@ def get_reasoning(response: AIMessage) -> str:
 
 
 class LLMClient:
-    """Dynamically create a retryable Runnable that handles structured output and tool calling.
+    """Dynamically create a Runnable to invoke LLMs with structured output, tool calling and retry.
 
     Usage:
         client = LLMClient(config)
@@ -134,21 +134,22 @@ class LLMClient:
         # With tools only
         response = await client.ainvoke(messages, tools=my_tools)
 
-        # With structured output only (returns AIMessage with JSON .text)
+        # With structured output only
         response = await client.ainvoke(messages, output_schema=MyModel)
 
-        # With both tools and structured output
+        # With retry only
+        response = await client.ainvoke(messages, retry_config=retry_config)
+
+        # With tools and structured output
         response = await client.ainvoke(messages, tools=my_tools, output_schema=MyModel)
 
-        # Pre-build a runnable for repeated use in a loop
-        runnable = client.get_runnable(tools=my_tools, output_schema=MyModel)
-        response = await runnable.ainvoke(messages)
+        # With tools, structured output and retry
+        response = await client.ainvoke(messages, tools=my_tools, output_schema=MyModel, retry_config=retry_config)
     """
 
     def __init__(self, config: LLMConfig):
         """Initialize the LLMClient with a configuration."""
         self._base_llm: BaseChatModel = create_llm(config)
-        self._retry_config: dict = config.retry_config
 
     async def ainvoke(
         self,
@@ -181,7 +182,6 @@ class LLMClient:
         if output_schema:
             model = model.bind(**self._structured_output_bind_kwargs(output_schema))
 
-        retry_config = retry_config or self._retry_config
         if retry_config:
             model = model.with_retry(**retry_config)
 

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -177,7 +177,10 @@ class LLMClient:
         model: Runnable = self._base_llm
 
         if tools:
-            model = self._base_llm.bind_tools(tools)
+            # OpenAI requires strict=True when combining tools with structured output
+            # other providers default to None (omit the field)
+            strict = True if isinstance(self._base_llm, ChatOpenAI) and output_schema else None
+            model = self._base_llm.bind_tools(tools, strict=strict)
 
         if output_schema:
             model = model.bind(**self._structured_output_bind_kwargs(output_schema))


### PR DESCRIPTION
I have added support for Claude 4.6 and I have added default configurations for Sonnet and Opus 4.6.

With 4.6, Anthropic have changed how the API works. To support it, I have had to modify our custom version of invoking LLMs with tools and structured output. In doing so, I have refactored it entirely introducing an `LLMClient` that binds tools, sets structured output, and retry configuration on demand with a single interface. With the introduction of the `LLMClient`, I had to adapt the tool-calling code, so I have taken the chance to refactor our loop and extracted it into a reusable `agentic_loop` function. These couple of things have greatly simplified our agent code.

The code still requires manual maintenance for the structured output API of each provider, but I did not find a reasonable way to reconcile tools and structured output with LangChain.

Closes AxiomaticX/ax-agent#657