### PR TITLE
Add commands to submit batch jobs

### DIFF
--- a/gcp/Makefile
+++ b/gcp/Makefile
@@ -29,3 +29,10 @@ build-base:
 
 build-runner:
 	@cd "$(REPO_ROOT)" && bash gcp/scripts/build_runner.sh "$(or $(AX_TAG),latest)" "$(or $(BASE_TAG),main)"
+
+submit:
+	@cd "$(REPO_ROOT)" && bash gcp/scripts/submit_batch_job.sh \
+		--dataset "$(DATASET)" \
+		--config-file "$(CONFIG)" \
+		$(if $(NAME),--name "$(NAME)") \
+		$(if $(EXTRA),-- $(EXTRA))

--- a/gcp/Makefile
+++ b/gcp/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo "  make sync-envfile                     # sync .env.secrets.gcp to Secret Manager"
 	@echo "  make build-base                       # build base image (default: BENCH_REF=main)"
 	@echo "  make build-runner                     # build runner image (defaults: AX_TAG=latest, BASE_TAG=main)"
+	@echo "  make submit DATASET=... CONFIG=...    # submit a batch job (optional: NAME=..., EXTRA='--max-concurrency 35')"
 
 bootstrap:
 	@cd "$(REPO_ROOT)" && bash gcp/scripts/bootstrap.sh

--- a/gcp/Makefile
+++ b/gcp/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # Get repo root (parent of gcp/)
 REPO_ROOT := $(shell cd "$(dir $(lastword $(MAKEFILE_LIST)))/.." && pwd)
 
-.PHONY: help bootstrap put-secret sync-envfile build-base build-runner submit
+.PHONY: help bootstrap put-secret sync-envfile build-base build-runner submit submit-repeat
 
 help:
 	@echo "Run from gcp/ directory: cd gcp && make <target>"
@@ -15,6 +15,7 @@ help:
 	@echo "  make build-base                       # build base image (default: BENCH_REF=main)"
 	@echo "  make build-runner                     # build runner image (defaults: AX_TAG=latest, BASE_TAG=main)"
 	@echo "  make submit DATASET=... CONFIG=...    # submit a batch job (optional: NAME=..., EXTRA='--max-concurrency 35')"
+	@echo "  make submit-repeat DATASET=... CONFIG=... REPEAT=N  # submit N copies (optional: SLEEP=1, NAME=..., EXTRA=...)"
 
 bootstrap:
 	@cd "$(REPO_ROOT)" && bash gcp/scripts/bootstrap.sh
@@ -37,3 +38,12 @@ submit:
 		--config-file "$(CONFIG)" \
 		$(if $(NAME),--name "$(NAME)") \
 		$(if $(EXTRA),-- $(EXTRA))
+
+submit-repeat:
+	@for i in $$(seq 1 $(or $(REPEAT),1)); do \
+		echo "=== Submitting job $$i/$(or $(REPEAT),1) ==="; \
+		$(MAKE) submit DATASET="$(DATASET)" CONFIG="$(CONFIG)" \
+			$(if $(NAME),NAME="$(NAME)") \
+			$(if $(EXTRA),EXTRA="$(EXTRA)"); \
+		sleep $(or $(SLEEP),1); \
+	done

--- a/gcp/Makefile
+++ b/gcp/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # Get repo root (parent of gcp/)
 REPO_ROOT := $(shell cd "$(dir $(lastword $(MAKEFILE_LIST)))/.." && pwd)
 
-.PHONY: help bootstrap put-secret sync-envfile build-base build-runner
+.PHONY: help bootstrap put-secret sync-envfile build-base build-runner submit
 
 help:
 	@echo "Run from gcp/ directory: cd gcp && make <target>"


### PR DESCRIPTION
I have added a command to submit batch jobs. Calling the bash script was very cumbersome, so I have added a make command with intuitive arguments: `make submit DATASET=dataset_name CONFIG=config_file.yaml NAME=experiment_name EXTRA="--max-concurrency X"`. The name and extra are optional, and the extra arguments are the `ax-prover experiment` command options.

Additionally, I have added a command to submit repeated copies of the same job. This goes by `make submit-repeat DATASET=dataseT_name CONFIG=config_file.yaml REPEAT=N SLEEP=1 NAME=experiment_name EXTRA="--max-concurrency X"`. Here, the arguments are the same as above except that we can control the number of repetitions and sleep time. By default, they're both optional and set to 1.

Closes AxiomaticX/ax-agent#665

