### PR TITLE
Add arXiv badge and citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/ax-prover)](https://pypi.org/project/ax-prover/)
+[![arXiv](https://img.shields.io/badge/arXiv-2602.24273-b31b1b.svg)](https://arxiv.org/abs/2602.24273)
 
 A simple, modular agent that proves Lean 4 theorems through iterative refinement.
 It uses off-the-shelf LLMs (no fine-tuning) with a feedback loop, a memory system, and library search tools to achieve competitive results against highly-engineered systems that rely on specialized training and orders of magnitude more compute.
@@ -173,6 +174,9 @@ If you use ax-prover in your research, please cite:
 @article{axproverbase2026,
   title={A Minimal Agent for Automated Theorem Proving},
   author={Requena Pozo, Borja and Letson, Austin and Nowakowski, Krystian and Beltran Ferreiro, Izan and Sarra, Leopoldo},
-  year={2026}
+  year={2026},
+  eprint={2602.24273},
+  archivePrefix={arXiv},
+  url={https://arxiv.org/abs/2602.24273}
 }
 ```


### PR DESCRIPTION
Include an arXiv badge in the README and update the citation to reference the arXiv preprint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change limited to README badges and citation metadata; no code or runtime behavior impact.
> 
> **Overview**
> Adds an **arXiv badge** to `README.md` linking to preprint `2602.24273`.
> 
> Updates the `bibtex` citation to include arXiv metadata (`eprint`, `archivePrefix`, `url`) and adjusts formatting accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5003b587e2423d2fb8e4318167c8dbd3538738cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->