### PR TITLE
feat(prover): broaden search-tactic rejection beyond apply?/exact?

### DIFF
--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -46,6 +46,7 @@ from ..utils.files import read_file
 from ..utils.git import get_repo_metadata
 from ..utils.lean_interact import get_goal_state_at_sorries
 from ..utils.lean_parsing import (
+    SEARCH_TACTIC_PATTERN,
     find_declaration_by_name,
     list_all_declarations_in_lean_code,
     strip_comments,
@@ -393,7 +394,7 @@ class ProverAgent:
                     return {"messages": [feedback]}
 
                 tactic_count, tactic_locations = count_pattern(
-                    stripped_code, pattern=r"\b(apply|exact)\?"
+                    stripped_code, pattern=SEARCH_TACTIC_PATTERN
                 )
                 if tactic_count:
                     self.logger.info("The proposed code contains search tactics.")

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -47,6 +47,7 @@ from ..utils.git import get_repo_metadata
 from ..utils.lean_interact import get_goal_state_at_sorries
 from ..utils.lean_parsing import (
     SEARCH_TACTIC_PATTERN,
+    blank_string_literals,
     find_declaration_by_name,
     list_all_declarations_in_lean_code,
     strip_comments,
@@ -384,7 +385,9 @@ class ProverAgent:
                     )
                     return {"messages": [feedback]}
 
-                stripped_code = strip_comments(state.last_proposal.code)
+                # Blank string-literal contents so a tactic-like substring or the word
+                # "axiom" inside a string/docstring cannot falsely trigger the checks below.
+                stripped_code = blank_string_literals(strip_comments(state.last_proposal.code))
 
                 axiom_count, axiom_locations = count_pattern(stripped_code, pattern=r"\baxiom\b")
                 if axiom_count:

--- a/src/ax_prover/utils/__init__.py
+++ b/src/ax_prover/utils/__init__.py
@@ -7,6 +7,7 @@ from .git import get_git_hash, get_repo_metadata, is_git_dirty
 # Export Lean parsing utilities
 from .lean_parsing import (
     LEAN_KEYWORDS,
+    SEARCH_TACTIC_PATTERN,
     count_pattern,
     extract_function_from_content,
     extract_theorem_name,
@@ -63,6 +64,7 @@ __all__ = [
     "is_git_dirty",
     # Lean
     "LEAN_KEYWORDS",
+    "SEARCH_TACTIC_PATTERN",
     "count_pattern",
     "strip_comments",
     # Proving

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -16,6 +16,13 @@ logger = get_logger(__name__)
 # Lean keywords for declarations
 LEAN_KEYWORDS = [d.value for d in DeclarationType]
 
+# Search/suggestion tactics that emit "Try this" and must not appear in a final proof.
+# These names are tactic-only — none are API methods ending in "?", so real code like
+# List.find?, xs.head?, Array.get?, m.lookup? is NOT matched. Extend as needed.
+SEARCH_TACTICS = ("apply", "exact", "rw", "simp", "simp_all", "aesop", "observe")
+# Longer names first so "simp_all?" isn't shadowed by "simp".
+SEARCH_TACTIC_PATTERN = rf"\b({'|'.join(sorted(SEARCH_TACTICS, key=len, reverse=True))})\?"
+
 
 def count_pattern(
     content: str,

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -133,6 +133,81 @@ def strip_comments(src: str) -> str:
     return "".join(out)
 
 
+def blank_string_literals(src: str) -> str:
+    """Replace the CONTENTS of string literals with spaces, preserving the quotes.
+
+    Same state machine as `strip_comments` but inverted: comments are left intact while
+    the inside of `"..."` string literals is blanked (length and positions preserved,
+    surrounding quotes kept). Used before pattern checks (e.g. search-tactic or `axiom`
+    detection) so a tactic-like substring inside a string literal does not falsely match.
+    """
+
+    class ParsingState(Enum):
+        Out = 1
+        LineComment = 2
+        BlockComment = 3
+        StringLiteral = 4
+
+    state = ParsingState.Out
+    i = 0
+    depth = 0
+    out = []
+    n = len(src)
+
+    while i < n:
+        c = src[i]
+        c2 = src[i : i + 2]
+
+        if state == ParsingState.Out:
+            if c == '"':
+                state = ParsingState.StringLiteral
+                out.append(c)
+                i += 1
+            elif c2 == "--":
+                state = ParsingState.LineComment
+                out.append(c2)
+                i += 2
+            elif c2 == "/-":
+                state = ParsingState.BlockComment
+                depth = 1
+                out.append(c2)
+                i += 2
+            else:
+                out.append(c)
+                i += 1
+
+        elif state == ParsingState.LineComment:
+            if c == "\n":
+                state = ParsingState.Out
+            out.append(c)
+            i += 1
+
+        elif state == ParsingState.BlockComment:
+            if c2 == "/-":
+                depth += 1
+                out.append(c2)
+                i += 2
+            elif c2 == "-/":
+                depth -= 1
+                out.append(c2)
+                i += 2
+                if depth == 0:
+                    state = ParsingState.Out
+            else:
+                out.append(c)
+                i += 1
+
+        elif state == ParsingState.StringLiteral:
+            if c == '"':
+                state = ParsingState.Out
+                out.append(c)
+            else:
+                out.append(" " if c != "\n" else "\n")
+            i += 1
+
+    return "".join(out)
+
+
 def extract_function_from_content(content: str, function_name: str) -> str | None:
     """Extract a function/theorem/lemma definition from Lean code.
 

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -4,6 +4,7 @@ import pytest
 
 from ax_prover.models.declaration import Declaration, DeclarationType
 from ax_prover.utils.lean_parsing import (
+    SEARCH_TACTIC_PATTERN,
     count_pattern,
     extract_function_from_content,
     extract_theorem_name,
@@ -211,6 +212,29 @@ class TestCountPattern:
         """apply (without ?) is not flagged by the search tactics pattern."""
         code = "theorem foo : P := by\n  apply some_lemma"
         count, _ = count_pattern(code, pattern=r"\b(apply|exact)\?")
+        assert count == 0
+
+    @pytest.mark.parametrize(
+        "tactic", ["apply?", "exact?", "rw?", "simp?", "simp_all?", "aesop?", "observe?"]
+    )
+    def test_search_tactic_pattern_flags_all_search_tactics(self, tactic):
+        """SEARCH_TACTIC_PATTERN flags every known search/suggestion tactic."""
+        code = f"theorem foo : P := by\n  {tactic}"
+        count, _ = count_pattern(code, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 1
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "def f (xs : List Nat) := xs.find? (· > 0)",
+            "def g (xs : List Nat) := xs.head?",
+            "def h (a : Array Nat) := a.get? 0",
+            "def k (m : Std.HashMap Nat Nat) := m.lookup? 3",
+        ],
+    )
+    def test_search_tactic_pattern_does_not_flag_api_methods(self, code):
+        """Real API methods ending in '?' (find?/head?/get?/lookup?) are not flagged."""
+        count, _ = count_pattern(code, pattern=SEARCH_TACTIC_PATTERN)
         assert count == 0
 
     def test_sorry_pattern_does_not_match_axiom(self):

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -5,6 +5,7 @@ import pytest
 from ax_prover.models.declaration import Declaration, DeclarationType
 from ax_prover.utils.lean_parsing import (
     SEARCH_TACTIC_PATTERN,
+    blank_string_literals,
     count_pattern,
     extract_function_from_content,
     extract_theorem_name,
@@ -13,6 +14,58 @@ from ax_prover.utils.lean_parsing import (
     normalize_location,
     strip_comments,
 )
+
+
+class TestBlankStringLiterals:
+    """Tests for blank_string_literals function."""
+
+    def test_blanks_inner_content_preserves_quotes_and_length(self):
+        src = 'let x := "simp? in here"'
+        result = blank_string_literals(src)
+        assert len(result) == len(src)
+        assert result == 'let x := "' + " " * len("simp? in here") + '"'
+        # Quotes preserved, inner content blanked.
+        assert result[9] == '"'
+        assert result[-1] == '"'
+
+    def test_code_outside_strings_untouched(self):
+        src = "theorem foo : True := by simp"
+        assert blank_string_literals(src) == src
+
+    def test_search_tactic_inside_string_not_matched(self):
+        """count_pattern over blanked source no longer flags a tactic in a string."""
+        src = 'theorem foo : True := by trivial -- note: "use simp? here"'
+        stripped = strip_comments(src)
+        # Without blanking, the comment is gone but if it were a string it would match.
+        blanked = blank_string_literals(stripped)
+        count, _ = count_pattern(blanked, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 0
+
+    def test_search_tactic_in_string_literal_not_matched(self):
+        src = 'theorem foo : True := by exact (id "use simp? to solve" |> fun _ => trivial)'
+        blanked = blank_string_literals(strip_comments(src))
+        count, _ = count_pattern(blanked, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 0
+
+    def test_real_search_tactic_still_matched(self):
+        src = "theorem foo : True := by simp?"
+        blanked = blank_string_literals(strip_comments(src))
+        count, _ = count_pattern(blanked, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 1
+
+    def test_axiom_word_in_string_not_matched(self):
+        src = 'theorem foo : True := by exact (id "this is an axiom" |> fun _ => trivial)'
+        blanked = blank_string_literals(strip_comments(src))
+        count, _ = count_pattern(blanked, pattern=r"\baxiom\b")
+        assert count == 0
+
+    def test_empty_string(self):
+        assert blank_string_literals("") == ""
+
+    def test_no_strings_identity(self):
+        src = "def add (a b : Nat) : Nat := a + b"
+        assert blank_string_literals(src) == src
+
 
 SAMPLE_LEAN_CODE = r"""
 import Mathlib.Topology.Basic


### PR DESCRIPTION
Reject the full family of "Try this"-style search/suggestion tactics (`apply?, exact?, rw?, simp?, simp_all?, aesop?, observe?`) in final proofs, via a shared SEARCH_TACTIC_PATTERN constant used by the builder gate. Names are tactic-only, so API methods ending in '?' (List.find?, xs.head?, Array.get?, m.lookup?) are not matched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only static validation of proposed Lean code after a successful build; no auth, persistence, or runtime proof execution paths.
> 
> **Overview**
> Tightens the **builder gate** so accepted proofs cannot keep interactive “Try this” search tactics or spurious `axiom` hits from **string literals**.
> 
> A shared **`SEARCH_TACTIC_PATTERN`** now rejects **`apply?`, `exact?`, `rw?`, `simp?`, `simp_all?`, `aesop?`, and `observe?`** (not only `apply?`/`exact?`). The prover builder runs **`blank_string_literals`** after **`strip_comments`** before **`axiom`** and search-tactic **`count_pattern`** checks, so substrings like `simp?` or `axiom` inside quoted strings do not fail the build. Tests cover blanking behavior and confirm API-style `?` methods (**`find?`, `head?`, `get?`, `lookup?`**) are not flagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179d77cc93462fd83b02329defea221586e56304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->