### PR TITLE
Warn proposer about stripped standalone lemmas

### DIFF
--- a/src/ax_prover/models/messages.py
+++ b/src/ax_prover/models/messages.py
@@ -89,13 +89,15 @@ class BuildFailedFeedback(FeedbackMessage):
 
     feedback_type: Literal["build_failed"] = "build_failed"
     error_output: str
+    warning: str = ""
     is_success: bool = False
 
-    def __init__(self, error_output: str, **kwargs):
-        """Initialize with formatted error message."""
+    def __init__(self, error_output: str, warning: str = "", **kwargs):
+        """Initialize with formatted error message, optionally prefixed by a warning."""
         kwargs.pop("content", None)
-        content = f"BUILD FAILED:\n\n{error_output}"
-        super().__init__(content=content, error_output=error_output, **kwargs)
+        warning_prefix = f"{warning}\n\n" if warning else ""
+        content = f"{warning_prefix}BUILD FAILED:\n\n{error_output}"
+        super().__init__(content=content, error_output=error_output, warning=warning, **kwargs)
 
 
 class ReviewApprovedFeedback(FeedbackMessage):

--- a/src/ax_prover/models/proving.py
+++ b/src/ax_prover/models/proving.py
@@ -152,7 +152,10 @@ class ProverResult(BaseModel):
     )
     updated_theorem: str = Field(
         description=(
-            "Theorem item with proof body. Include the full theorem statement and proof.\n"
+            "The target theorem ONLY, with its proof body. Include the full theorem statement "
+            "and proof. Do NOT add standalone helper lemmas/defs/theorems: only the target is "
+            "kept before compilation, so any other top-level declaration is stripped and "
+            "references to it fail. Inline helpers with `have`/`let`/`let rec`/`where`.\n"
             "Example:\n"
             "theorem foo (n : Nat) : n + 0 = n := by\n"
             "  have h1 : n = n := rfl  -- TODO: Intermediate step\n"

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -47,6 +47,7 @@ from ..utils.git import get_repo_metadata
 from ..utils.lean_interact import get_goal_state_at_sorries
 from ..utils.lean_parsing import (
     find_declaration_by_name,
+    find_stripped_declaration_names,
     list_all_declarations_in_lean_code,
     strip_comments,
 )
@@ -322,6 +323,7 @@ class ProverAgent:
         if not state.last_proposal:
             raise Exception("Builder expects proposal")
 
+        stripped_declarations: list[str] = []
         if state.item.location:
             declarations = list_all_declarations_in_lean_code(state.last_proposal.code)
             proposed_proof = find_declaration_by_name(declarations, state.item.location.name)
@@ -331,6 +333,18 @@ class ProverAgent:
                 )
                 feedback = MissingTargetTheoremFeedback(theorem_name=state.item.location.name)
                 return {"messages": [feedback]}
+
+            # Only the target declaration survives application; any standalone helper
+            # lemmas/defs the proposer wrote are stripped before compilation, breaking
+            # references to them. Detect them so we can explain build failures.
+            stripped_declarations = find_stripped_declaration_names(
+                state.last_proposal.code, state.item.location.name
+            )
+            if stripped_declarations:
+                self.logger.info(
+                    f"Proposed code defines standalone declarations that will be stripped: "
+                    f"{', '.join(stripped_declarations)}"
+                )
 
         with TemporaryProposal(
             self.base_folder, state.item.location, state.last_proposal
@@ -409,7 +423,21 @@ class ProverAgent:
         state.metrics.compilation_error_count += 1
         self.logger.info("Build failed with errors:")
         self.logger.debug(message)
-        feedback = BuildFailedFeedback(error_output=self._build_error_processing(message))
+        warning = ""
+        if stripped_declarations:
+            names = ", ".join(f"`{n}`" for n in stripped_declarations)
+            warning = (
+                f"WARNING — STANDALONE DECLARATIONS STRIPPED: your proposal defined "
+                f"{len(stripped_declarations)} declaration(s) outside the target theorem "
+                f"'{state.item.location.name}': {names}. Only the target theorem is kept before "
+                "compilation, so these were removed and any reference to them fails with "
+                "'unknown identifier'. Do NOT define separate `lemma`/`def`/`theorem`; inline "
+                "every helper inside the proof body using `have`, `let`, `let rec`, or a `where` "
+                "clause."
+            )
+        feedback = BuildFailedFeedback(
+            error_output=self._build_error_processing(message), warning=warning
+        )
         return {
             "messages": [feedback],
             "metrics": state.metrics,

--- a/src/ax_prover/prover/prompts.py
+++ b/src/ax_prover/prover/prompts.py
@@ -23,6 +23,7 @@ Think carefully about the current proof state and the knowledge gathered from th
     - NEVER modify the theorem signature, name or type
     - Only change the proof body (after :=)
     - Work ONLY on the target theorem
+    - Do NOT define standalone helper lemmas, defs, or theorems outside the target. Only the target theorem is kept before compilation; any other top-level declaration is automatically stripped, so references to it fail with "unknown identifier". Inline every helper inside the proof body using `have`, `let`, `let rec`, or a `where` clause.
 
 2. **Proof Development Strategy**
     - Use appropriate Lean 4 tactics to make progress
@@ -54,7 +55,7 @@ Capitalize on the previous experience and respect the lessons learned from the p
 
 **updated_theorem**: Updated code for theorem
 - Theorem statement and proof body
-- It only contains the specific theorem that was changed
+- It only contains the specific theorem that was changed — NO standalone helper lemmas/defs (they get stripped); inline helpers with `have`/`let`/`let rec`/`where`
 </output-format>
 
 <examples>
@@ -134,6 +135,7 @@ You can use the tools provided to you to help you with your task.
     - NEVER modify the theorem signature, name or type
     - Only change the proof body (after :=)
     - Work ONLY on the target theorem
+    - Do NOT define standalone helper lemmas, defs, or theorems outside the target. Only the target theorem is kept before compilation; any other top-level declaration is automatically stripped, so references to it fail with "unknown identifier". Inline every helper inside the proof body using `have`, `let`, `let rec`, or a `where` clause.
 
 2. **Proof Development Strategy**
     - Use appropriate Lean 4 tactics to make progress
@@ -162,7 +164,7 @@ Think carefully about the theorem at hand, evaluate the most promissing approach
 
 **updated_theorem**: Updated code for theorem
 - Theorem statement and proof body
-- It only contains the specific theorem that was changed
+- It only contains the specific theorem that was changed — NO standalone helper lemmas/defs (they get stripped); inline helpers with `have`/`let`/`let rec`/`where`
 </output-format>
 
 <examples>

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -16,6 +16,25 @@ logger = get_logger(__name__)
 # Lean keywords for declarations
 LEAN_KEYWORDS = [d.value for d in DeclarationType]
 
+# Declaration types that introduce a real, keepable named declaration (the kind that
+# `TemporaryProposal` would strip if it is not the target). Structural/non-declaration
+# entries (Import, Namespace, Section, End, Open, Notation, syntax/macro/elab, ...) are
+# excluded: they are not standalone declarations and stripping them is not the concern.
+STRIPPABLE_DECLARATION_TYPES = frozenset(
+    {
+        DeclarationType.Definition,
+        DeclarationType.Theorem,
+        DeclarationType.Lemma,
+        DeclarationType.Instance,
+        DeclarationType.Structure,
+        DeclarationType.Class,
+        DeclarationType.Inductive,
+        DeclarationType.Axiom,
+        DeclarationType.Abbrev,
+        DeclarationType.NoncomputableDef,
+        DeclarationType.NoncomputableAbbrev,
+    }
+)
 
 def count_pattern(
     content: str,
@@ -186,7 +205,7 @@ def find_stripped_declaration_names(raw_code: str, target_name: str) -> list[str
     return [
         d.name
         for d in declarations
-        if d.name != target_name and d.declaration_type != DeclarationType.Import
+        if d.name != target_name and d.declaration_type in STRIPPABLE_DECLARATION_TYPES
     ]
 
 

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -173,6 +173,23 @@ def extract_function_from_content(content: str, function_name: str) -> str | Non
     return content[start_pos:end_pos].strip()
 
 
+def find_stripped_declaration_names(raw_code: str, target_name: str) -> list[str]:
+    """Names of top-level declarations that would be stripped when applying a proposal.
+
+    Only the target declaration survives `TemporaryProposal` application (it calls
+    `extract_function_from_content` to keep a single declaration). Any other top-level
+    `def`/`lemma`/`theorem`/etc. the proposer wrote is silently discarded, which breaks
+    references to it. This returns those soon-to-be-stripped declaration names so the
+    builder can warn the proposer.
+    """
+    declarations = list_all_declarations_in_lean_code(raw_code)
+    return [
+        d.name
+        for d in declarations
+        if d.name != target_name and d.declaration_type != DeclarationType.Import
+    ]
+
+
 def get_function_from_location(base_folder: str, location: Location) -> str | None:
     """Get a function/theorem/lemma definition using a Location object.
 

--- a/tests/unit/models/test_messages.py
+++ b/tests/unit/models/test_messages.py
@@ -204,3 +204,21 @@ class TestFeedbackConstructors:
         msg = cls(error_output="some error")
         assert isinstance(msg, BuildFailedFeedback)
         assert "some error" in msg.content
+
+
+class TestBuildFailedFeedbackWarning:
+    """BuildFailedFeedback can carry a warning shown to the proposer."""
+
+    def test_warning_included_in_content(self):
+        """When a warning is supplied, it appears alongside the build error."""
+        msg = BuildFailedFeedback(
+            error_output="unknown identifier `contains_insert`",
+            warning="Your standalone helper lemmas were removed before compiling.",
+        )
+        assert "standalone helper lemmas were removed" in msg.content
+        assert "unknown identifier `contains_insert`" in msg.content
+
+    def test_no_warning_by_default(self):
+        """Default behaviour is unchanged when no warning is supplied."""
+        msg = BuildFailedFeedback(error_output="some error")
+        assert msg.content == "BUILD FAILED:\n\nsome error"

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -8,6 +8,7 @@ from ax_prover.utils.lean_parsing import (
     extract_function_from_content,
     extract_theorem_name,
     find_declaration_by_name,
+    find_stripped_declaration_names,
     list_all_declarations_in_lean_code,
     normalize_location,
     strip_comments,
@@ -361,3 +362,39 @@ class TestFindDeclarationByName:
     def test_empty_list(self):
         """Returns None for empty declarations list."""
         assert find_declaration_by_name([], "foo") is None
+
+
+# Code where the proposer wrote standalone helper lemmas *before* the target
+# theorem. When the proposal is applied, only the target declaration survives
+# (see TemporaryProposal -> extract_function_from_content), so these helpers are
+# silently stripped and the target's references to them break.
+STRIPPED_HELPERS_CODE = r"""
+lemma contains_insert (n : Nat) : n = n := by rfl
+
+lemma contains_merge (n : Nat) : n = n := by rfl
+
+theorem decrease_priority_correctness (n : Nat) : n + 0 = n := by
+  rw [contains_insert]
+  rfl
+"""
+
+
+class TestFindStrippedDeclarationNames:
+    """Tests for detecting standalone declarations that get stripped on apply."""
+
+    def test_lists_helpers_other_than_target(self):
+        """Returns names of every top-level declaration except the target."""
+        result = find_stripped_declaration_names(
+            STRIPPED_HELPERS_CODE, "decrease_priority_correctness"
+        )
+        assert result == ["contains_insert", "contains_merge"]
+
+    def test_empty_when_only_target(self):
+        """No extra declarations -> nothing gets stripped."""
+        code = "theorem foo (n : Nat) : n + 0 = n := by simp"
+        assert find_stripped_declaration_names(code, "foo") == []
+
+    def test_detects_helper_after_target(self):
+        """Helpers defined after the target are also stripped."""
+        code = "theorem foo : True := by trivial\n\nlemma bar : True := by trivial\n"
+        assert find_stripped_declaration_names(code, "foo") == ["bar"]

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -398,3 +398,25 @@ class TestFindStrippedDeclarationNames:
         """Helpers defined after the target are also stripped."""
         code = "theorem foo : True := by trivial\n\nlemma bar : True := by trivial\n"
         assert find_stripped_declaration_names(code, "foo") == ["bar"]
+
+    def test_ignores_namespace_section_end_open(self):
+        """Structural commands (namespace/section/end/open) are never 'stripped' decls."""
+        code = "namespace Foo\n  theorem target : True := by sorry\nend Foo"
+        assert find_stripped_declaration_names(code, "target") == []
+
+    def test_ignores_file_level_open(self):
+        """A file-level `open` must not be reported as a stripped declaration."""
+        code = "open Nat\n\ntheorem target (n : Nat) : n = n := by rfl"
+        result = find_stripped_declaration_names(code, "target")
+        assert "Nat" not in result
+        assert result == []
+
+    def test_genuine_helper_still_reported_alongside_structural(self):
+        """A real standalone helper is reported even when wrapped in a namespace."""
+        code = (
+            "namespace Foo\n"
+            "lemma helper (n : Nat) : n = n := by rfl\n"
+            "theorem target (n : Nat) : n = n := by rfl\n"
+            "end Foo"
+        )
+        assert find_stripped_declaration_names(code, "target") == ["helper"]


### PR DESCRIPTION
The builder applies only the target theorem; standalone helper lemmas the proposer writes are silently stripped, causing confusing "unknown identifier" build errors (wasted ~42 iterations in a BinaryHeap trace).

- Prompt + schema now instruct the proposer to inline helpers (`have`/`let`/`let rec`/`where`) instead of defining standalone lemmas/defs.
- Builder detects stripped declarations and prepends an explanatory warning to the build-failure feedback the proposer sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to proposer prompts, structured-output descriptions, build-failure feedback, and parsing helpers; no security or persistence paths.
> 
> **Overview**
> Addresses confusing **unknown identifier** build failures when the proposer adds standalone helper `lemma`/`def`/`theorem` nodes: only the target declaration is applied before `lake build`, so those helpers are dropped silently.
> 
> **Proposer guidance** is tightened in iterative and single-shot system prompts and in the `ProverResult.updated_theorem` schema so the model must submit **only the target theorem** and inline helpers with `have`, `let`, `let rec`, or `where`.
> 
> The **builder** now parses proposed code with `find_stripped_declaration_names` (strippable top-level decls except the target) and, on compile failure, prefixes `BuildFailedFeedback` with an optional **warning** listing stripped names and explaining why references break. `BuildFailedFeedback` gains a `warning` field for that text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb3eb8b0f900782c0fb25da72e14977b1b40862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->