### PR TITLE
Local search: handle modifiers/attributes and namespace-qualified names

### DIFF
--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -104,23 +104,30 @@ def _iter_lean_files(root: Path) -> Iterator[Path]:
                 yield Path(dirpath) / filename
 
 
-def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str]]:
-    """`(simple_name, qualified_name)` for searchable declarations matching `query`.
+def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str, int]]:
+    """`(simple_name, qualified_name, occurrence)` for declarations matching `query`.
 
     Matching is case-insensitive against the namespace-QUALIFIED name, so a
     multi-word query like "BinaryTree insert" matches a `def insert` declared inside
     `namespace BinaryTree` as well as a top-level `def BinaryTree.insert`. The simple
     name (as written in source) is returned alongside, since block extraction and line
-    lookup operate on the source text. Preserves source order, de-duplicated by
-    qualified name.
+    lookup operate on the source text. `occurrence` is the 0-based index of this
+    declaration among all declarations sharing its simple name in the file, so callers
+    can disambiguate the correct block/line when the same simple name appears in several
+    namespaces. Preserves source order, de-duplicated by qualified name.
     """
     tokens = query.lower().split()
     if not tokens:
         return []
-    results: list[tuple[str, str]] = []
+    results: list[tuple[str, str, int]] = []
     seen: set[str] = set()
     namespace_stack: list[str | None] = []
+    # Count occurrences of each simple name across ALL declarations, so the index aligns
+    # with re.finditer order in extract_function_from_content / _declaration_line.
+    name_counts: dict[str, int] = {}
     for declaration in list_all_declarations_in_lean_code(content):
+        occurrence = name_counts.get(declaration.name, 0)
+        name_counts[declaration.name] = occurrence + 1
         declaration_type = declaration.declaration_type
         if declaration_type == DeclarationType.Namespace:
             namespace_stack.append(declaration.name)
@@ -143,19 +150,22 @@ def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str
             continue
         if all(token in qualified.lower() for token in tokens):
             seen.add(qualified)
-            results.append((declaration.name, qualified))
+            results.append((declaration.name, qualified, occurrence))
     return results
 
 
-def _declaration_line(content: str, name: str) -> int:
+def _declaration_line(content: str, name: str, occurrence: int = 0) -> int:
     """1-based line number where the declaration of `name` begins (keyword line).
 
-    Falls back to 1 if the declaration keyword cannot be located.
+    `occurrence` selects the N-th (0-based) declaration with this simple name, matching
+    extract_function_from_content, so duplicates across namespaces resolve to the right
+    line. Falls back to 1 if the declaration keyword cannot be located.
     """
     pattern = rf"^\s*{DECL_PREFIX}(?:{_KEYWORDS_PATTERN})\s+{re.escape(name)}{DECL_NAME_END}"
-    match = re.search(pattern, content, re.MULTILINE)
-    if match is None:
+    matches = list(re.finditer(pattern, content, re.MULTILINE))
+    if occurrence >= len(matches):
         return 1
+    match = matches[occurrence]
     # With re.MULTILINE, `^` anchors at a line start and the following `\s*` can span
     # blank lines and indentation, so match.start() may precede the keyword line.
     # Advance past the matched leading whitespace to the keyword itself.
@@ -251,11 +261,13 @@ class LocalLeanSearcher:
             except (OSError, UnicodeDecodeError) as exc:
                 logger.debug(f"Skipping unreadable Lean file {lean_file}: {exc}")
                 continue
-            for simple_name, qualified_name in _matching_declaration_names(content, query):
-                block = extract_function_from_content(content, simple_name)
+            for simple_name, qualified_name, occurrence in _matching_declaration_names(
+                content, query
+            ):
+                block = extract_function_from_content(content, simple_name, occurrence)
                 if block is None:
                     continue
-                line = _declaration_line(content, simple_name)
+                line = _declaration_line(content, simple_name, occurrence)
                 grouped.setdefault((qualified_name, block), []).append(
                     (lean_file.relative_to(root), line)
                 )

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -18,6 +18,7 @@ from ..models.declaration import DeclarationType
 from ..utils import get_logger
 from ..utils.lean_parsing import (
     DECL_NAME_END,
+    DECL_PREFIX,
     LEAN_KEYWORDS,
     extract_function_from_content,
     list_all_declarations_in_lean_code,
@@ -88,7 +89,10 @@ def _walk_down_for_roots(start: Path) -> list[Path]:
     return roots
 
 
-_KEYWORDS_PATTERN = "|".join(re.escape(keyword) for keyword in LEAN_KEYWORDS)
+# Longest-first so compound keywords like `noncomputable def` win over the bare `def`.
+_KEYWORDS_PATTERN = "|".join(
+    re.escape(keyword) for keyword in sorted(LEAN_KEYWORDS, key=len, reverse=True)
+)
 
 
 def _iter_lean_files(root: Path) -> Iterator[Path]:
@@ -100,26 +104,47 @@ def _iter_lean_files(root: Path) -> Iterator[Path]:
                 yield Path(dirpath) / filename
 
 
-def _matching_declaration_names(content: str, query: str) -> list[str]:
-    """Names of searchable declarations matching `query` (case-insensitive).
+def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str]]:
+    """`(simple_name, qualified_name)` for searchable declarations matching `query`.
 
-    A multi-word query matches names that contain every whitespace-separated
-    token, so "Treap insert" matches `Treap.insert` (a single-word query keeps
-    the original substring behaviour). Preserves source order, de-duplicated.
+    Matching is case-insensitive against the namespace-QUALIFIED name, so a
+    multi-word query like "BinaryTree insert" matches a `def insert` declared inside
+    `namespace BinaryTree` as well as a top-level `def BinaryTree.insert`. The simple
+    name (as written in source) is returned alongside, since block extraction and line
+    lookup operate on the source text. Preserves source order, de-duplicated by
+    qualified name.
     """
     tokens = query.lower().split()
     if not tokens:
         return []
-    names: list[str] = []
+    results: list[tuple[str, str]] = []
     seen: set[str] = set()
+    namespace_stack: list[str | None] = []
     for declaration in list_all_declarations_in_lean_code(content):
-        if declaration.declaration_type not in SEARCHABLE_TYPES:
+        declaration_type = declaration.declaration_type
+        if declaration_type == DeclarationType.Namespace:
+            namespace_stack.append(declaration.name)
             continue
-        name_lower = declaration.name.lower()
-        if all(token in name_lower for token in tokens) and declaration.name not in seen:
-            seen.add(declaration.name)
-            names.append(declaration.name)
-    return names
+        if declaration_type == DeclarationType.Section:
+            namespace_stack.append(None)  # sections do not contribute to the name
+            continue
+        if declaration_type == DeclarationType.End:
+            if namespace_stack:
+                namespace_stack.pop()
+            continue
+        if declaration_type not in SEARCHABLE_TYPES:
+            continue
+        prefix = ".".join(part for part in namespace_stack if part)
+        if prefix and not declaration.name.startswith(f"{prefix}."):
+            qualified = f"{prefix}.{declaration.name}"
+        else:
+            qualified = declaration.name
+        if qualified in seen:
+            continue
+        if all(token in qualified.lower() for token in tokens):
+            seen.add(qualified)
+            results.append((declaration.name, qualified))
+    return results
 
 
 def _declaration_line(content: str, name: str) -> int:
@@ -127,7 +152,7 @@ def _declaration_line(content: str, name: str) -> int:
 
     Falls back to 1 if the declaration keyword cannot be located.
     """
-    pattern = rf"^\s*(?:{_KEYWORDS_PATTERN})\s+{re.escape(name)}{DECL_NAME_END}"
+    pattern = rf"^\s*{DECL_PREFIX}(?:{_KEYWORDS_PATTERN})\s+{re.escape(name)}{DECL_NAME_END}"
     match = re.search(pattern, content, re.MULTILINE)
     if match is None:
         return 1
@@ -217,8 +242,8 @@ class LocalLeanSearcher:
             logger.warning(f"LocalLeanSearch: {error}")
             return error
 
-        # Group by (name, block): identical declarations copied into several files
-        # collapse to one entry recording every location, preserving first-seen order.
+        # Group by (qualified_name, block): identical declarations copied into several
+        # files collapse to one entry recording every location, preserving first-seen order.
         grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
         for lean_file in _iter_lean_files(root):
             try:
@@ -226,12 +251,14 @@ class LocalLeanSearcher:
             except (OSError, UnicodeDecodeError) as exc:
                 logger.debug(f"Skipping unreadable Lean file {lean_file}: {exc}")
                 continue
-            for name in _matching_declaration_names(content, query):
-                block = extract_function_from_content(content, name)
+            for simple_name, qualified_name in _matching_declaration_names(content, query):
+                block = extract_function_from_content(content, simple_name)
                 if block is None:
                     continue
-                line = _declaration_line(content, name)
-                grouped.setdefault((name, block), []).append((lean_file.relative_to(root), line))
+                line = _declaration_line(content, simple_name)
+                grouped.setdefault((qualified_name, block), []).append(
+                    (lean_file.relative_to(root), line)
+                )
 
         if not grouped:
             logger.info(f"LocalLeanSearch: No results for '{query}'")

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -149,12 +149,17 @@ def strip_comments(src: str) -> str:
     return "".join(out)
 
 
-def extract_function_from_content(content: str, function_name: str) -> str | None:
+def extract_function_from_content(
+    content: str, function_name: str, occurrence: int = 0
+) -> str | None:
     """Extract a function/theorem/lemma definition from Lean code.
 
     Args:
         content: Lean code content as string
         function_name: Name of the function/theorem/lemma to extract
+        occurrence: 0-based index to disambiguate when several declarations share the
+            same simple name in one file (e.g. `A.insert` and `B.insert` written as
+            `def insert` inside different namespaces). 0 selects the first.
 
     Returns:
         The complete definition block including doc comments, or None
@@ -162,9 +167,10 @@ def extract_function_from_content(content: str, function_name: str) -> str | Non
     keywords_pattern = "|".join(LEAN_KEYWORDS)
     pattern = rf"^(\s*){DECL_PREFIX}(?:{_KEYWORDS_ALT})\s+{re.escape(function_name)}{DECL_NAME_END}"
 
-    match = re.search(pattern, content, re.MULTILINE)
-    if not match:
+    matches = list(re.finditer(pattern, content, re.MULTILINE))
+    if occurrence >= len(matches):
         return None
+    match = matches[occurrence]
 
     start_pos = match.start()
     start_indent = len(match.group(1))

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -22,6 +22,23 @@ LEAN_KEYWORDS = [d.value for d in DeclarationType]
 # wrongly match the earlier "Treap.insert" declaration.
 DECL_NAME_END = r"(?![^\s:({\[\]},])"
 
+# Modifiers that may precede a declaration keyword (e.g. `private def`, `partial def`).
+# `noncomputable` is intentionally absent: it is folded into the compound keywords
+# `noncomputable def` / `noncomputable abbrev` enumerated in DeclarationType.
+DECL_MODIFIERS = ("private", "protected", "partial", "unsafe", "nonrec", "scoped", "local")
+
+# Optional, inline declaration prefix matched before the keyword: zero or more attribute
+# lists (`@[simp]`, `@[simp, reducible]`) followed by zero or more modifier words. Uses
+# `[ \t]` (not `\s`) so it never spans newlines; nested `]` inside `@[...]` is unsupported.
+DECL_PREFIX = (
+    r"(?:@\[[^\]]*\][ \t]*)*"
+    rf"(?:(?:{'|'.join(DECL_MODIFIERS)})[ \t]+)*"
+)
+
+# Declaration keyword alternation, longest-first so compound keywords like
+# `noncomputable def` win over the bare `def`.
+_KEYWORDS_ALT = "|".join(re.escape(kw) for kw in sorted(LEAN_KEYWORDS, key=len, reverse=True))
+
 
 def count_pattern(
     content: str,
@@ -143,7 +160,7 @@ def extract_function_from_content(content: str, function_name: str) -> str | Non
         The complete definition block including doc comments, or None
     """
     keywords_pattern = "|".join(LEAN_KEYWORDS)
-    pattern = rf"^(\s*)({keywords_pattern})\s+{re.escape(function_name)}{DECL_NAME_END}"
+    pattern = rf"^(\s*){DECL_PREFIX}(?:{_KEYWORDS_ALT})\s+{re.escape(function_name)}{DECL_NAME_END}"
 
     match = re.search(pattern, content, re.MULTILINE)
     if not match:
@@ -165,8 +182,9 @@ def extract_function_from_content(content: str, function_name: str) -> str | Non
             break
 
     # Find next definition, doc comment, structural keyword, or top-level comment
-    # at same or lower indentation
-    end_pattern = rf"^[ \t]{{0,{start_indent}}}(/--|--|{keywords_pattern}(?:\s+|\b))"
+    # at same or lower indentation. The next declaration may itself carry an
+    # attribute/modifier prefix (e.g. `@[simp] def`), so allow DECL_PREFIX before it.
+    end_pattern = rf"^[ \t]{{0,{start_indent}}}(/--|--|{DECL_PREFIX}(?:{_KEYWORDS_ALT})(?:\s+|\b))"
 
     remaining_content = content[match.end() :]
     end_match = re.search(end_pattern, remaining_content, re.MULTILINE)
@@ -334,12 +352,16 @@ def list_all_declarations_in_lean_code(raw_code: str) -> list[Declaration]:
 
     declarations = []
     declaration = None
-    declaration_pattern = re.compile(r"(\w+)\s+([^\s:({[\]},]+)\s*(.*)")
+    # Match an optional attribute/modifier prefix, then the keyword (longest-first so
+    # `noncomputable def` beats `def`), the name, and the rest of the line.
+    declaration_pattern = re.compile(
+        rf"^{DECL_PREFIX}({_KEYWORDS_ALT})\s+([^\s:({{[\]}},]+)\s*(.*)"
+    )
     code = strip_comments(raw_code)
 
     for line in code.split("\n"):
         declaration_match = declaration_pattern.match(line.strip())
-        if declaration_match and declaration_match.group(1) in DeclarationType:
+        if declaration_match:
             if declaration is not None:
                 declarations.append(declaration)
             declaration = Declaration(
@@ -443,8 +465,7 @@ def find_declaration_at_line(content: str, line_number: int) -> str | None:
     if line_number > len(lines):
         return None
 
-    keywords_pattern = "|".join(LEAN_KEYWORDS)
-    pattern = rf"^(\s*)({keywords_pattern})\s+([\w.]+)"
+    pattern = rf"^(\s*){DECL_PREFIX}({_KEYWORDS_ALT})\s+([\w.]+)"
 
     declarations: list[tuple[str, int, int]] = []
 

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -126,15 +126,15 @@ class TestScanHelpers:
         # Declarations live inside `namespace Treaps`, so results are qualified.
         names = _matching_declaration_names(SAMPLE_LEAN, "treap")
         assert names == [
-            ("Treap", "Treaps.Treap"),
-            ("Treap.insert", "Treaps.Treap.insert"),
-            ("treap_insert_size", "Treaps.treap_insert_size"),
+            ("Treap", "Treaps.Treap", 0),
+            ("Treap.insert", "Treaps.Treap.insert", 0),
+            ("treap_insert_size", "Treaps.treap_insert_size", 0),
         ]
 
     def test_matching_names_excludes_structural_keywords(self):
         # "Treaps" (the namespace) must not be returned as a declaration.
         names = _matching_declaration_names(SAMPLE_LEAN, "Treap")
-        assert "Treaps" not in [simple for simple, _ in names]
+        assert "Treaps" not in [simple for simple, *_ in names]
 
     def test_matching_names_no_match_returns_empty(self):
         assert _matching_declaration_names(SAMPLE_LEAN, "nonexistent") == []
@@ -144,14 +144,14 @@ class TestScanHelpers:
         # not require the literal two-word substring (which never matches a name).
         names = _matching_declaration_names(SAMPLE_LEAN, "Treap insert")
         assert names == [
-            ("Treap.insert", "Treaps.Treap.insert"),
-            ("treap_insert_size", "Treaps.treap_insert_size"),
+            ("Treap.insert", "Treaps.Treap.insert", 0),
+            ("treap_insert_size", "Treaps.treap_insert_size", 0),
         ]
 
     def test_matching_names_multiword_ignores_extra_whitespace(self):
         assert _matching_declaration_names(SAMPLE_LEAN, "  Treap   insert ") == [
-            ("Treap.insert", "Treaps.Treap.insert"),
-            ("treap_insert_size", "Treaps.treap_insert_size"),
+            ("Treap.insert", "Treaps.Treap.insert", 0),
+            ("treap_insert_size", "Treaps.treap_insert_size", 0),
         ]
 
     def test_matching_names_multiword_excludes_partial_token_match(self):
@@ -372,28 +372,28 @@ class TestNamespaceQualification:
     def test_qualifies_namespaced_declaration(self):
         # `def insert` inside `namespace BinaryTree` is reachable via "BinaryTree insert".
         names = _matching_declaration_names(NAMESPACED_LEAN, "BinaryTree insert")
-        assert ("insert", "BinaryTree.insert") in names
+        assert ("insert", "BinaryTree.insert", 0) in names
 
     def test_simple_name_preserved_for_extraction(self):
         # The simple (source) name must remain available for block extraction.
         names = _matching_declaration_names(NAMESPACED_LEAN, "BinaryTree insert")
-        simple, qualified = next(pair for pair in names if pair[1] == "BinaryTree.insert")
+        simple, qualified, _ = next(t for t in names if t[1] == "BinaryTree.insert")
         assert simple == "insert"
 
     def test_section_does_not_contribute_to_name(self):
         # `section Helpers` must NOT prefix `in_section`.
         names = _matching_declaration_names(NAMESPACED_LEAN, "in_section")
-        assert names == [("in_section", "in_section")]
+        assert names == [("in_section", "in_section", 0)]
 
     def test_no_double_qualification(self):
         code = "namespace A.B\n\ndef A.B.f : Nat := 0\n\nend A.B\n"
         names = _matching_declaration_names(code, "f")
-        assert names == [("A.B.f", "A.B.f")]
+        assert names == [("A.B.f", "A.B.f", 0)]
 
     def test_nested_dotted_namespace(self):
         code = "namespace A.B\n\ndef f : Nat := 0\n\nend A.B\n"
         names = _matching_declaration_names(code, "f")
-        assert names == [("f", "A.B.f")]
+        assert names == [("f", "A.B.f", 0)]
 
     def test_search_displays_qualified_name_for_namespaced_def(self, namespaced_project):
         searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(namespaced_project))
@@ -413,3 +413,43 @@ class TestModifiedDeclarationSearch:
         searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(namespaced_project))
         result = searcher.search("topLevelTagged")
         assert "def topLevelTagged" in result
+
+
+# Two declarations sharing a simple name in different namespaces, same file.
+DUP_SIMPLE_NAME_LEAN = """namespace A
+
+def insert (t : T) : T := AAA
+
+end A
+
+namespace B
+
+def insert (t : T) : T := BBB
+
+end B
+"""
+
+
+@pytest.fixture
+def dup_name_project(tmp_path):
+    root = tmp_path / "challenges"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "challenges"\n')
+    (root / "Challenges" / "Dup.lean").write_text(DUP_SIMPLE_NAME_LEAN)
+    return root
+
+
+class TestAmbiguousSimpleName:
+    def test_matching_names_reports_distinct_occurrences(self):
+        names = _matching_declaration_names(DUP_SIMPLE_NAME_LEAN, "insert")
+        # Each match carries (simple, qualified, occurrence) so the right block can be found.
+        assert names == [("insert", "A.insert", 0), ("insert", "B.insert", 1)]
+
+    def test_search_shows_correct_block_and_line_per_namespace(self, dup_name_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(dup_name_project))
+        result = searcher.search("insert")
+        # Both bodies must appear, each at its own line — not the first block twice.
+        assert ":= AAA" in result
+        assert ":= BBB" in result
+        assert "Challenges/Dup.lean:3" in result  # A.insert
+        assert "Challenges/Dup.lean:9" in result  # B.insert

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -123,13 +123,18 @@ class TestScanHelpers:
         assert found == {"A.lean", "B.lean"}
 
     def test_matching_names_case_insensitive_substring(self):
+        # Declarations live inside `namespace Treaps`, so results are qualified.
         names = _matching_declaration_names(SAMPLE_LEAN, "treap")
-        assert names == ["Treap", "Treap.insert", "treap_insert_size"]
+        assert names == [
+            ("Treap", "Treaps.Treap"),
+            ("Treap.insert", "Treaps.Treap.insert"),
+            ("treap_insert_size", "Treaps.treap_insert_size"),
+        ]
 
     def test_matching_names_excludes_structural_keywords(self):
-        # "Treaps" (the namespace) must not be returned even though it matches.
+        # "Treaps" (the namespace) must not be returned as a declaration.
         names = _matching_declaration_names(SAMPLE_LEAN, "Treap")
-        assert "Treaps" not in names
+        assert "Treaps" not in [simple for simple, _ in names]
 
     def test_matching_names_no_match_returns_empty(self):
         assert _matching_declaration_names(SAMPLE_LEAN, "nonexistent") == []
@@ -138,12 +143,15 @@ class TestScanHelpers:
         # "Treap insert" should match names containing BOTH "treap" and "insert",
         # not require the literal two-word substring (which never matches a name).
         names = _matching_declaration_names(SAMPLE_LEAN, "Treap insert")
-        assert names == ["Treap.insert", "treap_insert_size"]
+        assert names == [
+            ("Treap.insert", "Treaps.Treap.insert"),
+            ("treap_insert_size", "Treaps.treap_insert_size"),
+        ]
 
     def test_matching_names_multiword_ignores_extra_whitespace(self):
         assert _matching_declaration_names(SAMPLE_LEAN, "  Treap   insert ") == [
-            "Treap.insert",
-            "treap_insert_size",
+            ("Treap.insert", "Treaps.Treap.insert"),
+            ("treap_insert_size", "Treaps.treap_insert_size"),
         ]
 
     def test_matching_names_multiword_excludes_partial_token_match(self):
@@ -328,3 +336,80 @@ class TestRegistration:
         tool = create_search_lean_local_tool(SearchLeanLocalConfig(), base_folder=str(proj))
         result = tool.func("myThing")
         assert "def myThing" in result
+
+
+# A project exercising namespace qualification and modifier/attribute handling.
+NAMESPACED_LEAN = """import Mathlib
+
+namespace BinaryTree
+
+def insert (t : BinaryTree) (k : Nat) : BinaryTree :=
+  t
+
+noncomputable def dijkstra_rec (g : G) (s : V) : T :=
+  foo
+
+end BinaryTree
+
+@[simp] private def topLevelTagged : Nat := 0
+
+section Helpers
+def in_section : Nat := 1
+end Helpers
+"""
+
+
+@pytest.fixture
+def namespaced_project(tmp_path):
+    root = tmp_path / "challenges"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "challenges"\n')
+    (root / "Challenges" / "Defs.lean").write_text(NAMESPACED_LEAN)
+    return root
+
+
+class TestNamespaceQualification:
+    def test_qualifies_namespaced_declaration(self):
+        # `def insert` inside `namespace BinaryTree` is reachable via "BinaryTree insert".
+        names = _matching_declaration_names(NAMESPACED_LEAN, "BinaryTree insert")
+        assert ("insert", "BinaryTree.insert") in names
+
+    def test_simple_name_preserved_for_extraction(self):
+        # The simple (source) name must remain available for block extraction.
+        names = _matching_declaration_names(NAMESPACED_LEAN, "BinaryTree insert")
+        simple, qualified = next(pair for pair in names if pair[1] == "BinaryTree.insert")
+        assert simple == "insert"
+
+    def test_section_does_not_contribute_to_name(self):
+        # `section Helpers` must NOT prefix `in_section`.
+        names = _matching_declaration_names(NAMESPACED_LEAN, "in_section")
+        assert names == [("in_section", "in_section")]
+
+    def test_no_double_qualification(self):
+        code = "namespace A.B\n\ndef A.B.f : Nat := 0\n\nend A.B\n"
+        names = _matching_declaration_names(code, "f")
+        assert names == [("A.B.f", "A.B.f")]
+
+    def test_nested_dotted_namespace(self):
+        code = "namespace A.B\n\ndef f : Nat := 0\n\nend A.B\n"
+        names = _matching_declaration_names(code, "f")
+        assert names == [("f", "A.B.f")]
+
+    def test_search_displays_qualified_name_for_namespaced_def(self, namespaced_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(namespaced_project))
+        result = searcher.search("BinaryTree insert")
+        assert 'matching "BinaryTree insert"' in result
+        assert "def insert (t : BinaryTree)" in result  # block is the source text
+
+
+class TestModifiedDeclarationSearch:
+    def test_search_finds_noncomputable_def(self, namespaced_project):
+        # Regression: `noncomputable def` declarations were invisible to search.
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(namespaced_project))
+        result = searcher.search("dijkstra_rec")
+        assert "noncomputable def dijkstra_rec" in result
+
+    def test_search_finds_attributed_private_def(self, namespaced_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(namespaced_project))
+        result = searcher.search("topLevelTagged")
+        assert "def topLevelTagged" in result

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -7,6 +7,7 @@ from ax_prover.utils.lean_parsing import (
     count_pattern,
     extract_function_from_content,
     extract_theorem_name,
+    find_declaration_at_line,
     find_declaration_by_name,
     list_all_declarations_in_lean_code,
     normalize_location,
@@ -375,3 +376,89 @@ class TestFindDeclarationByName:
     def test_empty_list(self):
         """Returns None for empty declarations list."""
         assert find_declaration_by_name([], "foo") is None
+
+
+class TestModifiersAndAttributes:
+    """Declarations carrying modifiers (`noncomputable`/`partial`/`private`/...) or inline
+    attributes (`@[simp]`) must be parsed, extracted, and located like any other decl.
+
+    These were previously dropped because the parser keyed off the first whitespace-delimited
+    word, which for `noncomputable def foo` was `noncomputable` (not a keyword).
+    """
+
+    @pytest.mark.parametrize(
+        ("code", "expected_type", "expected_name"),
+        [
+            (
+                "noncomputable def dijkstra_rec (g : G) : T := foo",
+                DeclarationType.NoncomputableDef,
+                "dijkstra_rec",
+            ),
+            (
+                "noncomputable abbrev weightSum : Nat := 0",
+                DeclarationType.NoncomputableAbbrev,
+                "weightSum",
+            ),
+            ("partial def dRec (x : Nat) : Nat := dRec x", DeclarationType.Definition, "dRec"),
+            ("private def secret : Nat := 1", DeclarationType.Definition, "secret"),
+            ("protected def prot : Nat := 2", DeclarationType.Definition, "prot"),
+            ("unsafe def danger : Nat := 0", DeclarationType.Definition, "danger"),
+            ("@[simp] def tagged : Nat := 0", DeclarationType.Definition, "tagged"),
+            ("@[simp, reducible] private def both : Nat := 0", DeclarationType.Definition, "both"),
+        ],
+    )
+    def test_modified_declaration_detected(self, code, expected_type, expected_name):
+        decls = list_all_declarations_in_lean_code(code)
+        assert len(decls) == 1
+        assert decls[0].declaration_type == expected_type
+        assert decls[0].name == expected_name
+
+    def test_names_are_correct_for_modified_decls(self):
+        code = (
+            "noncomputable def relax_neighbors (g : G) : T := foo\n"
+            "private def secret : Nat := 1\n"
+            "@[simp] def tagged : Nat := 0\n"
+        )
+        names = [d.name for d in list_all_declarations_in_lean_code(code)]
+        assert names == ["relax_neighbors", "secret", "tagged"]
+
+    def test_modifier_word_in_body_is_not_a_false_positive(self):
+        # A body line beginning with a modifier-like identifier must not be parsed as a decl.
+        code = "theorem foo : T := by\n  private_helper := bar\n  exact x"
+        names = [d.name for d in list_all_declarations_in_lean_code(code)]
+        assert names == ["foo"]
+
+    def test_extract_noncomputable_def_block(self):
+        code = (
+            "/-- Relaxes neighbours. -/\n"
+            "noncomputable def relax_neighbors (g : G) : T :=\n"
+            "  foo\n\n"
+            "def other : Nat := 0\n"
+        )
+        block = extract_function_from_content(code, "relax_neighbors")
+        assert block is not None
+        assert block.startswith("/-- Relaxes neighbours. -/")
+        assert "noncomputable def relax_neighbors" in block
+        assert "def other" not in block  # stops before the next declaration
+
+    def test_extract_stops_before_next_attributed_decl(self):
+        code = "def first : Nat := 0\n@[simp] def second : Nat := 1\n"
+        block = extract_function_from_content(code, "first")
+        assert block is not None
+        assert "second" not in block
+
+    def test_extract_attributed_def_block(self):
+        code = "@[simp] def tagged : Nat := 0\n"
+        block = extract_function_from_content(code, "tagged")
+        assert block is not None
+        assert block.startswith("@[simp] def tagged")
+
+    def test_find_declaration_by_name_finds_noncomputable_target(self):
+        # Coupling guard: the builder verifies the target via find_declaration_by_name; a
+        # `noncomputable def` target used to be invisible -> false MissingTargetTheorem.
+        decls = list_all_declarations_in_lean_code("noncomputable def foo := 1")
+        assert find_declaration_by_name(decls, "foo") is not None
+
+    def test_sorry_inside_noncomputable_def_attributed_to_it(self):
+        code = "noncomputable def foo : Nat := by\n  sorry"
+        assert find_declaration_at_line(code, 2) == "foo"


### PR DESCRIPTION
Fixes the local Lean search tool against feedback from the AI4Math experiment. Investigation **overturned the report's "missing/unindexed files" diagnosis** — the files are scanned; the parser was dropping declarations.

## Root causes (confirmed against the live parser + real challenge files)
- **Modifiers/attributes** defeat the keyword match: `noncomputable def`, `partial def`, `private def`, `@[simp] def` etc. were silently skipped. The four "missing" Tier-1 identifiers — `dijkstra_rec`, `relax_neighbors`, `isAncestor`, `weightSum` — are **all `noncomputable def`**.
- **Namespace qualification**: `def insert` inside `namespace BinaryTree` parsed as `insert`, so `"BinaryTree insert"` couldn't match.

## Changes
- **Shared parser (`lean_parsing.py`)**: match an optional inline attribute/modifier prefix before the keyword, longest-first so `noncomputable def` beats `def`. Applied to the lister, block extractor (start + end patterns), and `find_declaration_at_line`. Strictly additive for all consumers; also fixes a latent bug where a `noncomputable def` *target* was invisible to the builder (false `MissingTargetTheorem`).
- **Search tool (`local_lean_search.py`)**: track namespace/section scope and match queries against the fully-qualified name, keeping the simple source name for block extraction/line lookup.

## Verification
- Full unit suite green (300 tests; +23 new covering modifiers, attributes, namespace qualification, and coupling guards).
- End-to-end against the AI4Math challenges: `dijkstra_rec`, `relax_neighbors`, `weightSum`, `isAncestor`, and `"BinaryTree insert"` all now resolve (previously empty).

Deferred to a follow-up: nested `where` / `let rec` helper discovery (e.g. `query_aux`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Lean parsing regexes used by search and the proof builder; behavior is broader but well-covered by new tests, with some edge cases (nested `@[...]`) still unsupported.
> 
> **Overview**
> Fixes local Lean search and shared declaration parsing so **modified and namespaced declarations** are no longer skipped or mis-matched.
> 
> **`lean_parsing.py`** now recognizes optional `@[...]` attributes and modifier words before declaration keywords, with **longest-first** keyword matching so `noncomputable def` is parsed as a real declaration. That logic is applied to listing declarations, extracting definition blocks (including an optional **`occurrence`** index for duplicate simple names), and **`find_declaration_at_line`**.
> 
> **`local_lean_search.py`** matches queries against **namespace-qualified** names (e.g. `"BinaryTree insert"` → `BinaryTree.insert`), returns qualified names in results, and uses **simple name + occurrence** for correct block extraction and line numbers when the same name appears in multiple namespaces.
> 
> Adds unit coverage for modifiers, attributes, namespace qualification, and ambiguous `insert` defs across namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129f4d86d12569bbfd93a9025583a8a16fe3d8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->