### PR TITLE
Local search: body-search fallback + CSLib search tool

### DIFF
--- a/docs/superpowers/plans/2026-06-05-local-search-coverage-and-cslib.md
+++ b/docs/superpowers/plans/2026-06-05-local-search-coverage-and-cslib.md
@@ -1,0 +1,917 @@
+# Local Search Coverage + CSLib Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the prover's local Lean search find identifiers used in declaration bodies (e.g. `where`/`let rec` helpers like `query_aux`) and add a `search_cslib` tool that searches the vendored CSLib dependency; separately bump the proposer prompt to Lean 4.28.
+
+**Architecture:** Extract the per-directory search routine of `LocalLeanSearcher` into a shared module-level `_search_root`. Add a **body-search fallback** that runs only when name matching finds nothing, matching query tokens as whole identifiers inside declaration blocks. Add a sibling `CslibSearcher`/`search_cslib` tool that resolves `<lake_root>/.lake/packages/cslib` relative to the project and reuses `_search_root` (inheriting the fallback). The shared declaration parser is untouched.
+
+**Tech Stack:** Python 3.12, pytest, ruff, OmegaConf YAML configs, LangChain `StructuredTool`.
+
+**Branch:** `local-search-body-and-cslib` (already created off `local-lean-search-tool`). PR A = this plan. PR B (prompt 4.28) is a separate tiny branch off `main` — see the final section.
+
+---
+
+## File Structure
+
+- `src/ax_prover/tools/local_lean_search.py` — MODIFY: extract `_iter_searchable` + `_search_root`; add `_identifier_match`, `_body_matching_declarations`; `_format_results` gains `body_match`; `LocalLeanSearcher.search` delegates to `_search_root`.
+- `src/ax_prover/tools/cslib_search.py` — CREATE: `CSLIB_SEARCH_TOOL_TYPE`, `SearchCslibConfig`, `CslibSearcher`, `CslibSearchInput`, `create_search_cslib_tool`.
+- `src/ax_prover/tools/__init__.py` — MODIFY: export `create_search_cslib_tool`.
+- `src/ax_prover/configs/tools.yaml` — MODIFY: add `search_cslib` tool_config.
+- `src/ax_prover/configs/default.yaml` — MODIFY: add `search_cslib` to `proposer_tools`.
+- `tests/unit/tools/test_local_lean_search.py` — MODIFY: body-search tests.
+- `tests/unit/tools/test_cslib_search.py` — CREATE: CSLib tricky-retrieval tests.
+- `src/ax_prover/prover/prompts.py` — MODIFY (PR B, separate branch): Lean 4.24 → 4.28.
+
+Run tests with `.venv/bin/pytest`; format/lint with `.venv/bin/ruff`.
+
+---
+
+## Task 1: Refactor — extract `_search_root` (no behavior change)
+
+Pure refactor; the existing test suite is the safety net.
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py`
+
+- [ ] **Step 1: Add `_iter_searchable` helper above `_matching_declaration_names`**
+
+Insert this function immediately before `def _matching_declaration_names` (currently line 107):
+
+```python
+def _iter_searchable(content: str):
+    """Yield (declaration, qualified_name, occurrence) for each searchable declaration.
+
+    Tracks namespace/section scope to build the qualified name and counts per-simple-name
+    occurrences (aligned with re.finditer order in extract_function_from_content /
+    _declaration_line). Shared by name matching and body-search fallback.
+    """
+    namespace_stack: list[str | None] = []
+    name_counts: dict[str, int] = {}
+    for declaration in list_all_declarations_in_lean_code(content):
+        occurrence = name_counts.get(declaration.name, 0)
+        name_counts[declaration.name] = occurrence + 1
+        declaration_type = declaration.declaration_type
+        if declaration_type == DeclarationType.Namespace:
+            namespace_stack.append(declaration.name)
+            continue
+        if declaration_type == DeclarationType.Section:
+            namespace_stack.append(None)  # sections do not contribute to the name
+            continue
+        if declaration_type == DeclarationType.End:
+            if namespace_stack:
+                namespace_stack.pop()
+            continue
+        if declaration_type not in SEARCHABLE_TYPES:
+            continue
+        prefix = ".".join(part for part in namespace_stack if part)
+        if prefix and not declaration.name.startswith(f"{prefix}."):
+            qualified = f"{prefix}.{declaration.name}"
+        else:
+            qualified = declaration.name
+        yield declaration, qualified, occurrence
+```
+
+- [ ] **Step 2: Rewrite `_matching_declaration_names` to use it**
+
+Replace the body of `_matching_declaration_names` (keep the signature and docstring) with:
+
+```python
+    tokens = query.lower().split()
+    if not tokens:
+        return []
+    results: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    for declaration, qualified, occurrence in _iter_searchable(content):
+        if qualified in seen:
+            continue
+        if all(token in qualified.lower() for token in tokens):
+            seen.add(qualified)
+            results.append((declaration.name, qualified, occurrence))
+    return results
+```
+
+- [ ] **Step 3: Add module-level `_collect_matches` and `_search_root`**
+
+Insert immediately before `class LocalLeanSearcher` (currently line 211):
+
+```python
+def _collect_matches(
+    root: Path, query: str, *, body: bool
+) -> list[tuple[str, str, list[tuple[Path, int]]]]:
+    """Scan every .lean file under `root` and group matches by (qualified_name, block).
+
+    `body=False` matches declaration names; `body=True` matches query tokens as whole
+    identifiers inside declaration blocks (the fallback). Identical blocks copied across
+    files collapse to one entry recording every location.
+    """
+    grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
+    for lean_file in _iter_lean_files(root):
+        try:
+            content = lean_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug(f"Skipping unreadable Lean file {lean_file}: {exc}")
+            continue
+        matches = (
+            _body_matching_declarations(content, query)
+            if body
+            else _matching_declaration_names(content, query)
+        )
+        for simple_name, qualified_name, occurrence in matches:
+            block = extract_function_from_content(content, simple_name, occurrence)
+            if block is None:
+                continue
+            line = _declaration_line(content, simple_name, occurrence)
+            grouped.setdefault((qualified_name, block), []).append(
+                (lean_file.relative_to(root), line)
+            )
+    return [(name, block, locations) for (name, block), locations in grouped.items()]
+
+
+def _search_root(
+    root: Path, query: str, config: SearchLeanLocalConfig, *, label: str = "LocalLeanSearch"
+) -> str:
+    """Search `root` by declaration name; fall back to body search only if name finds nothing."""
+    decls = _collect_matches(root, query, body=False)
+    if decls:
+        logger.info(f"{label}: Found {len(decls)} declarations for '{query}' under {root}")
+        return _format_results(query, decls, config)
+    body_decls = _collect_matches(root, query, body=True)
+    if body_decls:
+        logger.info(
+            f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}"
+        )
+        return _format_results(query, body_decls, config, body_match=True)
+    logger.info(f"{label}: No results for '{query}'")
+    return f'No declarations matching "{query}" found.'
+```
+
+Note: `_body_matching_declarations` and the `body_match` parameter of `_format_results` are added in Tasks 2–4; this task will not run its new code path until then, but the module must still import — so also do Step 4 now.
+
+- [ ] **Step 4: Point `LocalLeanSearcher.search` at `_search_root` and keep the existing log message format**
+
+Replace the body of `LocalLeanSearcher.search` (currently lines 244–283) from the `# Group by ...` comment onward with:
+
+```python
+        return _search_root(root, query, self.config)
+```
+
+So the method reads in full:
+
+```python
+    def search(self, query: str) -> str:
+        query = query.strip()
+        logger.debug(f"LocalLeanSearch tool invoked with query: '{query}'")
+        if not query:
+            return "Please provide a non-empty keyword to search for."
+
+        root, error = self._resolve_root()
+        if root is None:
+            logger.warning(f"LocalLeanSearch: {error}")
+            return error
+
+        return _search_root(root, query, self.config)
+```
+
+- [ ] **Step 5: Add a temporary stub so the module imports before Tasks 2–4**
+
+At the end of the module-level functions (just before `class LocalLeanSearcher`), add a stub that Task 3 will replace:
+
+```python
+def _body_matching_declarations(content: str, query: str) -> list[tuple[str, str, int]]:
+    """Placeholder replaced in Task 3."""
+    return []
+```
+
+And add `body_match: bool = False` to `_format_results`'s signature now (unused until Task 4) so `_search_root` calls type-check:
+
+```python
+def _format_results(
+    query: str,
+    declarations: list[tuple[str, str, list[tuple[Path, int]]]],
+    config: SearchLeanLocalConfig,
+    body_match: bool = False,
+) -> str:
+```
+
+- [ ] **Step 6: Run the existing suite — must stay green (characterization)**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -q`
+Expected: PASS (same count as before the refactor; existing log-assertion tests still pass because the name-match path logs `Found N declarations for '...' under ...` and `No results for '...'`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py
+git commit -m "refactor(tools): extract _search_root + _iter_searchable from LocalLeanSearcher"
+```
+
+---
+
+## Task 2: `_identifier_match` (whole-identifier body matching)
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py`
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Add import + failing test**
+
+In `tests/unit/tools/test_local_lean_search.py`, add `_body_matching_declarations` and `_identifier_match` to the existing `from ax_prover.tools.local_lean_search import (...)` block, then append this test class:
+
+```python
+class TestIdentifierMatch:
+    def test_matches_standalone_identifier(self):
+        assert _identifier_match("query_aux", "  x := query_aux n 0")
+
+    def test_not_matched_inside_longer_identifier(self):
+        # trailing 'N' continues the identifier, so it is not a whole-identifier match
+        assert not _identifier_match("query_aux", "def query_auxN := 1")
+
+    def test_dot_is_an_identifier_boundary_char(self):
+        # '.' is part of a Lean identifier, so "insert" does NOT match inside "Treap.insert"
+        assert not _identifier_match("insert", "y := Treap.insert t")
+
+    def test_case_insensitive(self):
+        assert _identifier_match("foo", "exact FOO")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py::TestIdentifierMatch -q`
+Expected: FAIL (`cannot import name '_identifier_match'`).
+
+- [ ] **Step 3: Implement `_identifier_match`**
+
+In `src/ax_prover/tools/local_lean_search.py`, add near the other module helpers (e.g. after `_KEYWORDS_PATTERN`):
+
+```python
+# Characters that make up a Lean identifier; a body token matches only when flanked by
+# non-identifier characters (so "query_aux" won't hit inside "query_auxN" and "insert"
+# won't hit inside "Treap.insert").
+_IDENT_CHAR = r"[0-9A-Za-z_'.]"
+
+
+def _identifier_match(token: str, text: str) -> bool:
+    """True if `token` appears in `text` as a whole identifier (case-insensitive)."""
+    pattern = rf"(?<!{_IDENT_CHAR}){re.escape(token)}(?!{_IDENT_CHAR})"
+    return re.search(pattern, text, re.IGNORECASE) is not None
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py::TestIdentifierMatch -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat(tools): add whole-identifier body match helper"
+```
+
+---
+
+## Task 3: `_body_matching_declarations`
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py`
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Append failing tests**
+
+In `tests/unit/tools/test_local_lean_search.py`, add this fixture constant near the other inline samples and the test class:
+
+```python
+WHERE_BLOCK_LEAN = """import Mathlib
+
+def query (n : Nat) : Nat :=
+  query_aux n 0   where query_aux (j acc : Nat) : Nat :=
+    if j = 0 then acc else query_aux (j - 1) (acc + j)
+"""
+
+
+class TestBodyMatchingDeclarations:
+    def test_name_search_misses_where_helper(self):
+        # `query_aux` is not a top-level declaration, so name search returns nothing.
+        assert _matching_declaration_names(WHERE_BLOCK_LEAN, "query_aux") == []
+
+    def test_body_search_returns_enclosing_declaration(self):
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux") == [
+            ("query", "query", 0)
+        ]
+
+    def test_body_search_requires_all_tokens(self):
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux missing") == []
+
+    def test_body_search_respects_identifier_boundary(self):
+        # 'quer' is a prefix, not a whole identifier in the body → no match.
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "quer") == []
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py::TestBodyMatchingDeclarations -q`
+Expected: FAIL (`_body_matching_declarations` returns `[]` from the Task-1 stub, so `test_body_search_returns_enclosing_declaration` fails).
+
+- [ ] **Step 3: Replace the stub with the real implementation**
+
+In `src/ax_prover/tools/local_lean_search.py`, replace the `_body_matching_declarations` stub from Task 1 with:
+
+```python
+def _body_matching_declarations(content: str, query: str) -> list[tuple[str, str, int]]:
+    """`(simple_name, qualified_name, occurrence)` for declarations whose block text contains
+    every query token as a whole identifier. Fallback for identifiers that are not declaration
+    names themselves (e.g. `where`/`let rec` helpers, inductive constructors). De-duplicated by
+    qualified name, source order preserved.
+    """
+    tokens = query.lower().split()
+    if not tokens:
+        return []
+    results: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    for declaration, qualified, occurrence in _iter_searchable(content):
+        if qualified in seen:
+            continue
+        block = extract_function_from_content(content, declaration.name, occurrence)
+        if block is None:
+            continue
+        if all(_identifier_match(token, block) for token in tokens):
+            seen.add(qualified)
+            results.append((declaration.name, qualified, occurrence))
+    return results
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py::TestBodyMatchingDeclarations -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat(tools): body-search fallback finds identifiers used in declaration bodies"
+```
+
+---
+
+## Task 4: Wire the fallback end-to-end + `body_match` annotation
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py`
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Append failing integration tests**
+
+In `tests/unit/tools/test_local_lean_search.py`, append:
+
+```python
+@pytest.fixture
+def where_project(tmp_path):
+    root = tmp_path / "proj"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "p"\n')
+    (root / "Challenges" / "Q.lean").write_text(WHERE_BLOCK_LEAN)
+    return root
+
+
+class TestBodySearchEndToEnd:
+    def test_search_falls_back_to_body_for_where_helper(self, where_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        out = searcher.search("query_aux")
+        assert "def query" in out
+        assert "matched in body" in out
+        assert "Challenges/Q.lean:" in out
+
+    def test_name_match_does_not_use_body_fallback(self, where_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        out = searcher.search("query")
+        assert "def query" in out
+        assert "matched in body" not in out
+
+    def test_no_match_message_unchanged(self, where_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        assert searcher.search("zzz_nope") == 'No declarations matching "zzz_nope" found.'
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py::TestBodySearchEndToEnd -q`
+Expected: FAIL on `test_search_falls_back_to_body_for_where_helper` — `"matched in body"` is absent because `_format_results` ignores `body_match`.
+
+- [ ] **Step 3: Implement the `body_match` annotation in `_format_results`**
+
+In `_format_results`, just after computing `header`, add the note; and append it to each primary location header. The function body becomes:
+
+```python
+    header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+    note = " (matched in body)" if body_match else ""
+    shown: list[str] = []
+    overflow: list[str] = []
+    total = len(header)
+    for name, block, locations in declarations:
+        (primary_path, primary_line), *extra = locations
+        location_header = f"-- {primary_path}:{primary_line}{note}"
+        if extra:
+            also = ", ".join(f"{path}:{line}" for path, line in extra)
+            location_header += f" (also: {also})"
+        entry = f"{location_header}\n{block}"
+        within_budget = total + len(entry) + 2 <= config.max_chars
+        if len(shown) < config.max_results and within_budget:
+            shown.append(entry)
+            total += len(entry) + 2
+        else:
+            overflow.append(f"{name} ({primary_path}:{primary_line})")
+    output = header + "\n\n" + "\n\n".join(shown)
+    if overflow:
+        output += "\n\nAdditional matches (not shown, refine your query): " + ", ".join(overflow)
+    return output
+```
+
+- [ ] **Step 4: Run to verify pass + full file suite**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -q`
+Expected: PASS (all, including the three new end-to-end tests and every pre-existing test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat(tools): annotate body-match results and wire fallback through search"
+```
+
+---
+
+## Task 5: `search_cslib` tool (scaffold + registration + wiring)
+
+**Files:**
+- Create: `src/ax_prover/tools/cslib_search.py`
+- Modify: `src/ax_prover/tools/__init__.py`, `src/ax_prover/configs/tools.yaml`, `src/ax_prover/configs/default.yaml`
+- Test: `tests/unit/tools/test_cslib_search.py`
+
+- [ ] **Step 1: Write the first failing test**
+
+Create `tests/unit/tools/test_cslib_search.py`:
+
+```python
+"""Unit tests for the CSLib search tool."""
+
+import pytest
+
+from ax_prover.tools import create_search_cslib_tool
+from ax_prover.tools.cslib_search import (
+    CSLIB_SEARCH_TOOL_TYPE,
+    CslibSearcher,
+    SearchCslibConfig,
+)
+from ax_prover.tools.registry import TOOL_REGISTRY, create_tool
+
+
+def _make_project_with_cslib(tmp_path):
+    """A lake project whose .lake/packages/cslib holds one namespaced theorem."""
+    root = tmp_path / "proj"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "p"\n')
+    (root / "Challenges" / "Def_Local.lean").write_text("def ProjectOnlyThing : Nat := 0\n")
+    cslib = root / ".lake" / "packages" / "cslib" / "Cslib"
+    cslib.mkdir(parents=True)
+    (cslib / "Relation.lean").write_text(
+        "namespace WellFounded\n\ntheorem ofTransGen (h : True) : True := h\n\nend WellFounded\n"
+    )
+    return root
+
+
+class TestCslibBasic:
+    def test_finds_namespaced_theorem_qualified(self, tmp_path):
+        root = _make_project_with_cslib(tmp_path)
+        searcher = CslibSearcher(SearchCslibConfig(), base_folder=str(root))
+        out = searcher.search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+        assert "theorem ofTransGen" in out
+
+    def test_tool_type_constant(self):
+        assert CSLIB_SEARCH_TOOL_TYPE == "search_cslib"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_cslib_search.py -q`
+Expected: FAIL (`ModuleNotFoundError: ax_prover.tools.cslib_search`).
+
+- [ ] **Step 3: Create the tool module**
+
+Create `src/ax_prover/tools/cslib_search.py`:
+
+```python
+"""CSLib search tool.
+
+Searches the vendored CSLib dependency (under `.lake/packages/cslib`), which the local
+project search excludes and the Mathlib-only remote LeanSearch tool does not cover.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from ..utils import get_logger
+from .local_lean_search import (
+    _search_root,
+    _walk_down_for_roots,
+    _walk_up_for_root,
+)
+from .registry import register_tool, tool_name_from_type
+
+logger = get_logger(__name__)
+
+CSLIB_SEARCH_TOOL_TYPE = "search_cslib"
+
+
+@dataclass
+class SearchCslibConfig:
+    """Configuration for the CSLib search tool."""
+
+    max_results: int = 6
+    max_chars: int = 4000
+    package_subpath: str = ".lake/packages/cslib"
+
+
+class CslibSearcher:
+    """Searches the CSLib package, resolved relative to the project's lake root."""
+
+    def __init__(self, config: SearchCslibConfig, base_folder: str = "."):
+        self.config = config
+        self.base_folder = base_folder
+        self._resolution: tuple[Path | None, str] | None = None
+
+    def _resolve_cslib(self) -> tuple[Path | None, str]:
+        if self._resolution is None:
+            self._resolution = self._compute_cslib()
+        return self._resolution
+
+    def _compute_cslib(self) -> tuple[Path | None, str]:
+        start = Path(self.base_folder).resolve()
+        root = _walk_up_for_root(start)
+        if root is None:
+            down = _walk_down_for_roots(start)
+            root = down[0] if len(down) == 1 else None
+        if root is None:
+            return None, f"CSLib search unavailable: no lakefile found at or under {start}."
+        cslib = root / self.config.package_subpath
+        if not cslib.is_dir():
+            return None, (
+                f"CSLib search unavailable: '{self.config.package_subpath}' not found under {root}."
+            )
+        return cslib, ""
+
+    def search(self, query: str) -> str:
+        query = query.strip()
+        logger.debug(f"CslibSearch tool invoked with query: '{query}'")
+        if not query:
+            return "Please provide a non-empty keyword to search for."
+        cslib, error = self._resolve_cslib()
+        if cslib is None:
+            logger.warning(f"CslibSearch: {error}")
+            return error
+        return _search_root(cslib, query, self.config, label="CslibSearch")
+
+
+class CslibSearchInput(BaseModel):
+    query: str = Field(
+        ...,
+        description=(
+            "Keyword(s) to match against CSLib declaration names (case-insensitive). "
+            "Multiple words match names containing all of them, e.g. 'WellFounded ofTransGen'."
+        ),
+    )
+
+
+@register_tool(CSLIB_SEARCH_TOOL_TYPE, SearchCslibConfig)
+def create_search_cslib_tool(
+    config: SearchCslibConfig, base_folder: str = "."
+) -> StructuredTool:
+    """Create the CSLib search tool, scoped to the project's vendored cslib package."""
+    searcher = CslibSearcher(config, base_folder=base_folder)
+    return StructuredTool(
+        name=tool_name_from_type(CSLIB_SEARCH_TOOL_TYPE),
+        description="""Search the CSLib library for declarations by name.
+
+Returns the full source of CSLib `def`/`theorem`/`lemma`/`structure`/etc. whose name
+contains your keyword (case-insensitive). CSLib is a dependency the local project search
+does not cover and the Mathlib LeanSearch tool does not index.
+
+Pass a single keyword or multiple words (which must all appear in the qualified name, e.g.
+"WellFounded ofTransGen"). If no name matches, falls back to matching identifiers used in
+declaration bodies.""",
+        func=searcher.search,
+        args_schema=CslibSearchInput,
+    )
+```
+
+- [ ] **Step 4: Export the factory**
+
+In `src/ax_prover/tools/__init__.py`, add the import and `__all__` entry:
+
+```python
+from .cslib_search import create_search_cslib_tool
+```
+
+and add `"create_search_cslib_tool",` to the `__all__` list (next to `"create_search_lean_local_tool",`).
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_cslib_search.py::TestCslibBasic -q`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Add a registration test**
+
+Append to `tests/unit/tools/test_cslib_search.py`:
+
+```python
+class TestCslibRegistration:
+    def test_registered_in_registry(self):
+        assert CSLIB_SEARCH_TOOL_TYPE in TOOL_REGISTRY
+
+    @pytest.mark.asyncio
+    async def test_create_tool_builds_named_tool(self, tmp_path):
+        root = _make_project_with_cslib(tmp_path)
+        tool = await create_tool({"tool_type": "search_cslib"}, base_folder=str(root))
+        assert tool is not None
+        assert tool.name == "search_cslib_tool"
+```
+
+Run: `.venv/bin/pytest tests/unit/tools/test_cslib_search.py::TestCslibRegistration -q`
+Expected: PASS. (If `test_create_tool_builds_named_tool` errors with "async def not natively supported", confirm the repo's pytest-asyncio config; other async tests in `tests/unit/tools/test_lean_search.py` use the same style, so it is configured.)
+
+- [ ] **Step 7: Wire into bundled configs**
+
+In `src/ax_prover/configs/tools.yaml`, add under `tool_configs:` (after the `search_lean_local` block):
+
+```yaml
+  search_cslib:
+    tool_type: search_cslib
+    max_results: 6
+    max_chars: 4000
+```
+
+In `src/ax_prover/configs/default.yaml`, add to `proposer_tools:`:
+
+```yaml
+    search_cslib: ${tool_configs.search_cslib}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ax_prover/tools/cslib_search.py src/ax_prover/tools/__init__.py \
+        src/ax_prover/configs/tools.yaml src/ax_prover/configs/default.yaml \
+        tests/unit/tools/test_cslib_search.py
+git commit -m "feat(tools): add search_cslib tool and wire into bundled configs"
+```
+
+---
+
+## Task 6: CSLib tricky-retrieval test matrix
+
+The tool exists; these tests pin down the required behaviors. If any fails, fix the cause (likely in `cslib_search.py` or the shared `_search_root`) before moving on.
+
+**Files:**
+- Test: `tests/unit/tools/test_cslib_search.py`
+
+- [ ] **Step 1: Add tricky fixtures + tests**
+
+Append to `tests/unit/tools/test_cslib_search.py`:
+
+```python
+from ax_prover.tools.local_lean_search import LocalLeanSearcher, SearchLeanLocalConfig
+
+# CSLib-shaped content: module header, public import, namespace, doc + own-line @[simp],
+# noncomputable, private. `measure` here collides (different namespace/body) with the SKI file.
+CSLIB_REL = """module
+
+public import Cslib.Init
+
+namespace WellFounded
+
+/-- Transitive-closure well-foundedness. -/
+@[simp]
+theorem ofTransGen (h : True) : True := h
+
+noncomputable def measure : Nat := 0
+
+private theorem secret : True := trivial
+
+end WellFounded
+"""
+
+# Inductive with distinctive constructor names (Iterm is only a constructor, not a decl).
+CSLIB_SKI = """module
+namespace CombinatoryLogic
+
+inductive SKI where
+  | Sterm | Kterm | Iterm
+  | app : SKI -> SKI -> SKI
+
+def measure : SKI -> Nat
+  | _ => 1
+
+end CombinatoryLogic
+"""
+
+
+def _make_rich_cslib(tmp_path, *, with_mathlib=False):
+    root = tmp_path / "proj"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "p"\n')
+    (root / "Challenges" / "Def_Local.lean").write_text("def ProjectOnlyThing : Nat := 0\n")
+    cslib = root / ".lake" / "packages" / "cslib" / "Cslib"
+    cslib.mkdir(parents=True)
+    (cslib / "Relation.lean").write_text(CSLIB_REL)
+    (cslib / "SKI.lean").write_text(CSLIB_SKI)
+    if with_mathlib:
+        mathlib = root / ".lake" / "packages" / "mathlib" / "Mathlib"
+        mathlib.mkdir(parents=True)
+        (mathlib / "X.lean").write_text("def MathlibOnly : Nat := 1\n")
+    return root
+
+
+class TestCslibIsolation:
+    def test_cslib_tool_excludes_project_files(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("ProjectOnlyThing")
+        assert out == 'No declarations matching "ProjectOnlyThing" found.'
+
+    def test_cslib_tool_excludes_sibling_mathlib(self, tmp_path):
+        root = _make_rich_cslib(tmp_path, with_mathlib=True)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("MathlibOnly")
+        assert out == 'No declarations matching "MathlibOnly" found.'
+
+    def test_local_tool_excludes_cslib(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root)).search("ofTransGen")
+        assert out == 'No declarations matching "ofTransGen" found.'
+
+    def test_local_tool_finds_project_file(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root)).search(
+            "ProjectOnlyThing"
+        )
+        assert "def ProjectOnlyThing" in out
+
+
+class TestCslibModuleShapes:
+    def test_own_line_attribute_decl_found_and_block_includes_attr(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+        assert "theorem ofTransGen" in out
+        # Block extraction backscans to the doc comment, pulling the own-line @[simp] in too.
+        assert "@[simp]" in out
+
+    def test_module_and_public_import_do_not_create_bogus_results(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("Cslib")
+        # `public import Cslib.Init` is an import, not a searchable declaration.
+        assert out == 'No declarations matching "Cslib" found.'
+
+
+class TestCslibNamespaceAndDuplicates:
+    def test_multiword_qualified_query(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search(
+            "WellFounded ofTransGen"
+        )
+        assert "WellFounded.ofTransGen" in out
+
+    def test_duplicate_simple_name_across_files_resolves_distinctly(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("measure")
+        assert "WellFounded.measure" in out
+        assert "CombinatoryLogic.measure" in out
+        assert ":= 0" in out  # WellFounded.measure body
+        assert "SKI -> Nat" in out  # CombinatoryLogic.measure body
+
+
+class TestCslibModifiers:
+    def test_private_theorem_found(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("secret")
+        assert "WellFounded.secret" in out
+
+    def test_noncomputable_def_found(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("measure")
+        assert "noncomputable def measure" in out
+
+
+class TestCslibBodyAndConstructors:
+    def test_inductive_constructor_found_via_body(self, tmp_path):
+        # `Iterm` is a constructor, not a top-level decl: name search misses, body search hits SKI.
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("Iterm")
+        assert "inductive SKI" in out
+        assert "matched in body" in out
+
+
+class TestCslibEdges:
+    def test_missing_cslib_dir_message(self, tmp_path):
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "lakefile.toml").write_text('name = "p"\n')
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("anything")
+        assert "CSLib search unavailable" in out
+        assert ".lake/packages/cslib" in out
+
+    def test_resolves_from_subdirectory_walk_up(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        sub = root / "Challenges"
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(sub)).search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+
+    def test_resolves_from_parent_walk_down(self, tmp_path):
+        _make_rich_cslib(tmp_path)  # creates tmp_path/proj
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(tmp_path)).search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+
+    def test_caps_overflow_lists_extras(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(
+            SearchCslibConfig(max_results=1), base_folder=str(root)
+        ).search("measure")
+        assert "Additional matches" in out
+```
+
+- [ ] **Step 2: Run the full CSLib suite**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_cslib_search.py -q`
+Expected: PASS. If `test_module_and_public_import_do_not_create_bogus_results` fails because `public import Cslib.Init` is being surfaced, that is acceptable behavior to adjust — the import is parsed as an `import` declaration (not in `SEARCHABLE_TYPES`), so it should already be excluded; if not, investigate `_iter_searchable`. If `test_inductive_constructor_found_via_body` fails, verify the body-search fallback runs for the cslib root (it shares `_search_root`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/tools/test_cslib_search.py
+git commit -m "test(tools): tricky CSLib retrieval matrix (isolation, module shapes, dups, body, edges)"
+```
+
+---
+
+## Task 7: Full verification + push + PR A
+
+**Files:** none (verification + git)
+
+- [ ] **Step 1: Full unit suite**
+
+Run: `.venv/bin/pytest tests/unit -q`
+Expected: PASS (all green).
+
+- [ ] **Step 2: Format + lint**
+
+Run:
+```bash
+.venv/bin/ruff format src/ax_prover tests/unit
+.venv/bin/ruff check src/ax_prover/tools/local_lean_search.py src/ax_prover/tools/cslib_search.py tests/unit/tools/test_cslib_search.py tests/unit/tools/test_local_lean_search.py
+```
+Expected: "All checks passed!" (commit any reformat with `git commit -am "style: ruff format"`).
+
+- [ ] **Step 3: End-to-end smoke against the real dataset (read-only)**
+
+Run:
+```bash
+.venv/bin/python -c "
+from ax_prover.tools.local_lean_search import LocalLeanSearcher, SearchLeanLocalConfig
+from ax_prover.tools.cslib_search import CslibSearcher, SearchCslibConfig
+base='/Users/krystian/Documents/Axiomatic/Baku/AI4Math/challenges'
+print('--- query_aux (body fallback) ---')
+print(LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=base).search('query_aux')[:400])
+print('--- CSLib WellFounded ---')
+print(CslibSearcher(SearchCslibConfig(), base_folder=base).search('WellFounded')[:400])
+"
+```
+Expected: `query_aux` returns the `query` declaration flagged `(matched in body)`; the CSLib query returns a real CSLib declaration block.
+
+- [ ] **Step 4: Push and open PR A**
+
+```bash
+git push -u origin local-search-body-and-cslib
+gh pr create --base local-lean-search-tool --head local-search-body-and-cslib \
+  --title "Local search: body-search fallback + CSLib search tool" \
+  --body "Adds a body-search fallback (finds where/let-rec helpers and other body identifiers when no declaration name matches) and a new search_cslib tool that searches the vendored CSLib dependency. Includes a tricky CSLib retrieval test matrix. Design: docs/superpowers/specs/2026-06-05-local-search-coverage-and-cslib-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Follow-up: PR B — proposer prompt Lean 4.28 (separate branch off `main`)
+
+Not part of PR A. On a fresh branch off `main`:
+
+- [ ] In `src/ax_prover/prover/prompts.py` line 6, change `(Lean version 4.24)` → `(Lean version 4.28)`.
+- [ ] In `src/ax_prover/prover/prompts.py` line 127, change `(Lean version 4.24)` → `(Lean version 4.28)`.
+- [ ] `.venv/bin/pytest tests/unit -q` (green), commit `fix(prompts): target Lean 4.28 to match the AI4Math dataset`, push, open PR B → `main`.
+
+## Integration (after PR A + PR B merge)
+
+- [ ] Merge both into `run_AI4Math_Challange`.
+- [ ] On `run_AI4Math_Challange`, add `search_cslib: ${tool_configs.search_cslib}` to `proposer_tools` in the exp-only `configs/opus48_local.yaml`, and add the `search_cslib` tool_config to the repo-level `configs/tools.yaml` (the exp branch's copies), so the next experiment run uses the CSLib tool. Verify with `merge_configs(['opus48_local.yaml'], folder='.')`.

--- a/docs/superpowers/specs/2026-06-05-local-search-coverage-and-cslib-design.md
+++ b/docs/superpowers/specs/2026-06-05-local-search-coverage-and-cslib-design.md
@@ -1,0 +1,134 @@
+# Local search coverage + CSLib search + prompt Lean 4.28 — Design
+
+Date: 2026-06-05
+Status: Approved (brainstorming)
+
+## Context
+
+The prover's local Lean search (`search_lean_local`) is the agent's main way to understand the
+custom project environment. Checking it against the official AI4Math / Codabench dataset structure
+(Lean **4.28.0** + Mathlib + **CSLib**; `Def_*` files supply definitions, `Challenge_*` files each
+hold one `sorry`) revealed three gaps:
+
+1. **Identifiers defined inside `where` / `let rec` blocks are unfindable.** The parser only sees
+   column-anchored top-level keywords, so a helper like `query_aux` (defined in a `where` block in
+   `Challenges/Segment_Tree/Def_Query.lean`) returns no result. More generally, the tool can only
+   find a declaration by its *name*, never by something referenced in its *body*.
+2. **CSLib is unsearchable.** It is vendored at `<project>/.lake/packages/cslib/` (≈109 files, 189
+   namespaces). Local search excludes `.lake/` by design, and the remote LeanSearch tool is
+   Mathlib-only, so CSLib lemmas have no search path — a blind spot for challenges that use it
+   (notably Phase 2 Splay Tree / Spanner).
+3. **The proposer prompt states the wrong Lean version** ("Lean version 4.24") while the dataset is
+   4.28.0.
+
+Grounding confirmed CSLib declarations use no modifiers the parser misses (`noncomputable`,
+`private`/`partial`, inline `@[...]`, and namespaces are all already handled), so CSLib needs only
+to be *pointed at* — not parsed differently.
+
+## Design
+
+### 1. Body-search fallback (replaces a fragile where/let-rec parser)
+
+Rather than special-case `where`/`let rec` syntax (fragile, and only `query_aux` exists in the
+current dataset), generalize: search declaration **bodies** when a name search finds nothing.
+
+- Extract the per-root search body of `LocalLeanSearcher.search` into a shared module-level
+  `_search_root(root, query, config)` in `local_lean_search.py` (the grouping + `_format_results`
+  logic). `LocalLeanSearcher.search` keeps resolving the project root and delegates to it.
+- **Pass 1 — name match (unchanged):** namespace-qualified declaration-name matching, exactly as
+  today (modifiers/occurrence already handled).
+- **Pass 2 — body match (new; runs ONLY when Pass 1 returns zero):** for each declaration, if every
+  query token appears as a **whole identifier** (identifier-boundary, not raw substring) anywhere in
+  that declaration's block text, return the enclosing declaration's block. The result header is
+  annotated so the agent knows it was a body hit, e.g. `-- <path>:<line> (matched in body)`. Same
+  `max_results` / `max_chars` caps as name matches.
+- Net effect: `search("query_aux")` returns the `query` declaration block (query_aux is referenced
+  in its body). Generalizes to any identifier with no syntax special-casing.
+
+Identifier-boundary match: a token matches when bounded by non-identifier characters (Lean
+identifiers include letters, digits, `_`, `'`, and `.`), so `query_aux` does not match inside
+`query_auxiliary`.
+
+### 2. CSLib search — separate `search_cslib` tool
+
+A new tool, semantically distinct from project search, reusing the shared core.
+
+- New `src/ax_prover/tools/cslib_search.py`:
+  - `CSLIB_SEARCH_TOOL_TYPE = "search_cslib"`, `SearchCslibConfig` (`max_results`, `max_chars`,
+    and `package_subpath: str = ".lake/packages/cslib"`).
+  - `CslibSearcher`: reuse `LocalLeanSearcher`'s lake-root resolution
+    (`_walk_up_for_root` / `_walk_down_for_roots`), then search `root / package_subpath`, resolved
+    **relative to the project** (no hardcoded absolute path). If that directory is absent, return a
+    clear "CSLib not found under .lake/packages" message. Reuses `_search_root` + `_iter_lean_files`
+    (pointing the root *inside* cslib makes `.lake` exclusion irrelevant).
+  - `@register_tool(CSLIB_SEARCH_TOOL_TYPE, SearchCslibConfig)` factory `create_search_cslib_tool`
+    with a `base_folder` parameter so `create_tool` injects the project folder.
+- Inherits the body-search fallback automatically via the shared core.
+- Wiring (this PR, bundled configs): export in `src/ax_prover/tools/__init__.py`; add a
+  `search_cslib` `tool_config` to `src/ax_prover/configs/tools.yaml`; add `search_cslib` to
+  `proposer_tools` in `src/ax_prover/configs/default.yaml`.
+
+### 3. Prompt → Lean 4.28
+
+In `src/ax_prover/prover/prompts.py`, change the two "Lean version 4.24" occurrences to
+"Lean version 4.28". Leave generic "Lean 4" mentions unchanged.
+
+## Components / boundaries
+
+- `_search_root(root, query, config)` — pure "search one directory tree" unit; both tools depend on
+  it; independently testable.
+- `LocalLeanSearcher` — resolves the project root, delegates to `_search_root`.
+- `CslibSearcher` — resolves the project root, derives the cslib subdir, delegates to `_search_root`.
+- Body-search lives entirely inside `_search_root` (and a small identifier-match helper); the shared
+  parser `lean_parsing.py` is untouched, preserving builder/reviewer/stripped-lemma behavior.
+
+## Files
+
+- `src/ax_prover/tools/local_lean_search.py` — extract `_search_root`; add body-search fallback + identifier-match helper
+- `src/ax_prover/tools/cslib_search.py` — new tool
+- `src/ax_prover/tools/__init__.py`, `src/ax_prover/configs/tools.yaml`, `src/ax_prover/configs/default.yaml` — CSLib wiring
+- `src/ax_prover/prover/prompts.py` — Lean 4.28
+- `tests/unit/tools/test_local_lean_search.py` — body-search tests
+- `tests/unit/tools/test_cslib_search.py` — new CSLib tests
+
+## Tests (TDD: failing first)
+
+- Body-search (`test_local_lean_search.py`): a `where`-block fixture (the `query_aux` shape) —
+  `search("query_aux")` returns the enclosing `query` block, header flagged as a body match; a body
+  hit on an ordinary referenced identifier; identifier-boundary guard (token does not match inside a
+  longer identifier); and confirmation that body-search does NOT run when a name match exists.
+- CSLib (`test_cslib_search.py`): tmp lake project with `.lake/packages/cslib/Cslib/X.lean`
+  containing a namespaced `theorem` — found and namespace-qualified; missing-cslib-dir yields the
+  clear message; the cslib tool does NOT return the project's own (non-cslib) declarations.
+
+## Verification
+
+1. `.venv/bin/pytest tests/unit -q` green incl. new tests; `ruff format` + `ruff check` clean.
+2. End-to-end against the real dataset (read-only):
+   ```
+   .venv/bin/python -c "
+   from ax_prover.tools.local_lean_search import LocalLeanSearcher, SearchLeanLocalConfig
+   from ax_prover.tools.cslib_search import CslibSearcher, SearchCslibConfig
+   base='/Users/krystian/Documents/Axiomatic/Baku/AI4Math/challenges'
+   print(LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=base).search('query_aux')[:400])
+   print(CslibSearcher(SearchCslibConfig(), base_folder=base).search('WellFounded')[:400])
+   "
+   ```
+   Expect: `query_aux` returns the `query` block (flagged body match); CSLib query returns a CSLib
+   declaration.
+
+## Packaging / branching
+
+- **PR A** (this branch, `local-search-body-and-cslib`, based on `local-lean-search-tool`):
+  workstreams 1 + 2 — body-search fallback and the `search_cslib` tool, wired into the **bundled**
+  package configs.
+- **PR B** (separate, off `main`): workstream 3 — the Lean 4.28 prompt change.
+- Both merge into `run_AI4Math_Challange`. At exp-integration, also add `search_cslib` to the
+  exp-only `configs/opus48_local.yaml` `proposer_tools` so the next experiment run uses it (that
+  file does not exist on this feature branch).
+
+## Out of scope / deferred
+
+- No `where`/`let rec` AST parsing — the body-search fallback subsumes the need.
+- No caching of CSLib scans (≈5 MB per query). Acceptable for now; revisit if call latency matters.
+- CSLib path assumes the standard `.lake/packages/cslib` layout; configurable via `package_subpath`.

--- a/docs/superpowers/specs/2026-06-05-local-search-coverage-and-cslib-design.md
+++ b/docs/superpowers/specs/2026-06-05-local-search-coverage-and-cslib-design.md
@@ -97,9 +97,27 @@ In `src/ax_prover/prover/prompts.py`, change the two "Lean version 4.24" occurre
   `search("query_aux")` returns the enclosing `query` block, header flagged as a body match; a body
   hit on an ordinary referenced identifier; identifier-boundary guard (token does not match inside a
   longer identifier); and confirmation that body-search does NOT run when a name match exists.
-- CSLib (`test_cslib_search.py`): tmp lake project with `.lake/packages/cslib/Cslib/X.lean`
-  containing a namespaced `theorem` — found and namespace-qualified; missing-cslib-dir yields the
-  clear message; the cslib tool does NOT return the project's own (non-cslib) declarations.
+- CSLib (`test_cslib_search.py`): unit tests use **synthetic cslib-shaped `tmp_path` fixtures**
+  (the real CSLib lives in the AI4Math repo, not here / CI), with a real-CSLib check kept as the
+  manual verification step. Tricky retrieval matrix (all required):
+  1. **Isolation, both directions** — fixture with BOTH `.lake/packages/cslib/` and
+     `.lake/packages/mathlib/`: `search_cslib` returns cslib decls only (never mathlib, never the
+     project's own `Def_*/Challenge_*`); `search_lean_local` never returns cslib decls.
+  2. **Module-system shapes** — a cslib file beginning with `module` + `public import …` headers,
+     and an **own-line `@[simp]`** attribute (optionally with a `/-- … -/` doc comment) above a
+     `theorem`: the decl is still found by name and its block extracts sensibly (assert the
+     observed block boundaries, documenting whether the own-line attribute is included).
+  3. **Namespacing + cross-file duplicate names** — `theorem ofTransGen` in `namespace WellFounded`
+     found via `"WellFounded ofTransGen"`, shown qualified; the **same simple name in two cslib
+     files / namespaces with different bodies** resolves to two distinct results with correct
+     per-file paths/lines.
+  4. **Modifiers** — `noncomputable def` and `private theorem` in cslib are found.
+  5. **Body-search + inductive constructors** — a token referenced only inside a lemma body, and an
+     `inductive` constructor name (e.g. `S`/`K`/`I`, not a top-level decl), return the enclosing
+     declaration flagged as a body match.
+  6. **Edges** — missing cslib dir → clear message; caps overflow lists extras by name; cslib root
+     resolved relative to the project whether `base_folder` is the root, a subdir (walk-up), or the
+     parent (walk-down).
 
 ## Verification
 

--- a/src/ax_prover/configs/default.yaml
+++ b/src/ax_prover/configs/default.yaml
@@ -8,6 +8,7 @@ prover:
     search_lean: ${tool_configs.search_lean_search}
     search_web: ${tool_configs.search_web}
     search_lean_local: ${tool_configs.search_lean_local}
+    search_cslib: ${tool_configs.search_cslib}
   max_iterations: 50
   memory_config:
     class_name: ExperienceProcessor

--- a/src/ax_prover/configs/tools.yaml
+++ b/src/ax_prover/configs/tools.yaml
@@ -43,3 +43,8 @@ tool_configs:
     tool_type: search_lean_local
     max_results: 6
     max_chars: 4000
+
+  search_cslib:
+    tool_type: search_cslib
+    max_results: 6
+    max_chars: 4000

--- a/src/ax_prover/tools/__init__.py
+++ b/src/ax_prover/tools/__init__.py
@@ -1,11 +1,11 @@
 """Tools for the agents."""
 
+from .cslib_search import create_search_cslib_tool
 from .lean_search import (
     create_search_lean_search_tool,
     lean_search_session_manager,
     warmup_lean_search,
 )
-from .cslib_search import create_search_cslib_tool
 from .local_lean_search import create_search_lean_local_tool
 from .registry import TOOL_REGISTRY, create_tool, tool_name_from_type
 from .web_search import create_search_web_tool

--- a/src/ax_prover/tools/__init__.py
+++ b/src/ax_prover/tools/__init__.py
@@ -5,6 +5,7 @@ from .lean_search import (
     lean_search_session_manager,
     warmup_lean_search,
 )
+from .cslib_search import create_search_cslib_tool
 from .local_lean_search import create_search_lean_local_tool
 from .registry import TOOL_REGISTRY, create_tool, tool_name_from_type
 from .web_search import create_search_web_tool
@@ -15,6 +16,7 @@ __all__ = [
     "tool_name_from_type",
     "create_search_lean_search_tool",
     "create_search_lean_local_tool",
+    "create_search_cslib_tool",
     "create_search_web_tool",
     "lean_search_session_manager",
     "warmup_lean_search",

--- a/src/ax_prover/tools/cslib_search.py
+++ b/src/ax_prover/tools/cslib_search.py
@@ -1,0 +1,102 @@
+"""CSLib search tool.
+
+Searches the vendored CSLib dependency (under `.lake/packages/cslib`), which the local
+project search excludes and the Mathlib-only remote LeanSearch tool does not cover.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from ..utils import get_logger
+from .local_lean_search import (
+    _search_root,
+    _walk_down_for_roots,
+    _walk_up_for_root,
+)
+from .registry import register_tool, tool_name_from_type
+
+logger = get_logger(__name__)
+
+CSLIB_SEARCH_TOOL_TYPE = "search_cslib"
+
+
+@dataclass
+class SearchCslibConfig:
+    """Configuration for the CSLib search tool."""
+
+    max_results: int = 6
+    max_chars: int = 4000
+    package_subpath: str = ".lake/packages/cslib"
+
+
+class CslibSearcher:
+    """Searches the CSLib package, resolved relative to the project's lake root."""
+
+    def __init__(self, config: SearchCslibConfig, base_folder: str = "."):
+        self.config = config
+        self.base_folder = base_folder
+        self._resolution: tuple[Path | None, str] | None = None
+
+    def _resolve_cslib(self) -> tuple[Path | None, str]:
+        if self._resolution is None:
+            self._resolution = self._compute_cslib()
+        return self._resolution
+
+    def _compute_cslib(self) -> tuple[Path | None, str]:
+        start = Path(self.base_folder).resolve()
+        root = _walk_up_for_root(start)
+        if root is None:
+            down = _walk_down_for_roots(start)
+            root = down[0] if len(down) == 1 else None
+        if root is None:
+            return None, f"CSLib search unavailable: no lakefile found at or under {start}."
+        cslib = root / self.config.package_subpath
+        if not cslib.is_dir():
+            return None, (
+                f"CSLib search unavailable: '{self.config.package_subpath}' not found under {root}."
+            )
+        return cslib, ""
+
+    def search(self, query: str) -> str:
+        query = query.strip()
+        logger.debug(f"CslibSearch tool invoked with query: '{query}'")
+        if not query:
+            return "Please provide a non-empty keyword to search for."
+        cslib, error = self._resolve_cslib()
+        if cslib is None:
+            logger.warning(f"CslibSearch: {error}")
+            return error
+        return _search_root(cslib, query, self.config, label="CslibSearch")
+
+
+class CslibSearchInput(BaseModel):
+    query: str = Field(
+        ...,
+        description=(
+            "Keyword(s) to match against CSLib declaration names (case-insensitive). "
+            "Multiple words match names containing all of them, e.g. 'WellFounded ofTransGen'."
+        ),
+    )
+
+
+@register_tool(CSLIB_SEARCH_TOOL_TYPE, SearchCslibConfig)
+def create_search_cslib_tool(config: SearchCslibConfig, base_folder: str = ".") -> StructuredTool:
+    """Create the CSLib search tool, scoped to the project's vendored cslib package."""
+    searcher = CslibSearcher(config, base_folder=base_folder)
+    return StructuredTool(
+        name=tool_name_from_type(CSLIB_SEARCH_TOOL_TYPE),
+        description="""Search the CSLib library for declarations by name.
+
+Returns the full source of CSLib `def`/`theorem`/`lemma`/`structure`/etc. whose name
+contains your keyword (case-insensitive). CSLib is a dependency the local project search
+does not cover and the Mathlib LeanSearch tool does not index.
+
+Pass a single keyword or multiple words (which must all appear in the qualified name, e.g.
+"WellFounded ofTransGen"). If no name matches, falls back to matching identifiers used in
+declaration bodies.""",
+        func=searcher.search,
+        args_schema=CslibSearchInput,
+    )

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -95,6 +95,18 @@ _KEYWORDS_PATTERN = "|".join(
 )
 
 
+# Characters that make up a Lean identifier; a body token matches only when flanked by
+# non-identifier characters (so "query_aux" won't hit inside "query_auxN" and "insert"
+# won't hit inside "Treap.insert").
+_IDENT_CHAR = r"[0-9A-Za-z_'.]"
+
+
+def _identifier_match(token: str, text: str) -> bool:
+    """True if `token` appears in `text` as a whole identifier (case-insensitive)."""
+    pattern = rf"(?<!{_IDENT_CHAR}){re.escape(token)}(?!{_IDENT_CHAR})"
+    return re.search(pattern, text, re.IGNORECASE) is not None
+
+
 def _iter_lean_files(root: Path) -> Iterator[Path]:
     """Yield every .lean file under `root`, skipping the `.lake/` directory."""
     for dirpath, dirnames, filenames in os.walk(root):

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -231,12 +231,13 @@ def _format_results(
     caps) is listed by name.
     """
     header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+    note = " (matched in body)" if body_match else ""
     shown: list[str] = []
     overflow: list[str] = []
     total = len(header)
     for name, block, locations in declarations:
         (primary_path, primary_line), *extra = locations
-        location_header = f"-- {primary_path}:{primary_line}"
+        location_header = f"-- {primary_path}:{primary_line}{note}"
         if extra:
             also = ", ".join(f"{path}:{line}" for path, line in extra)
             location_header += f" (also: {also})"

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -176,8 +176,26 @@ def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str
 
 
 def _body_matching_declarations(content: str, query: str) -> list[tuple[str, str, int]]:
-    """Placeholder replaced in Task 3."""
-    return []
+    """`(simple_name, qualified_name, occurrence)` for declarations whose block text contains
+    every query token as a whole identifier. Fallback for identifiers that are not declaration
+    names themselves (e.g. `where`/`let rec` helpers, inductive constructors). De-duplicated by
+    qualified name, source order preserved.
+    """
+    tokens = query.lower().split()
+    if not tokens:
+        return []
+    results: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    for declaration, qualified, occurrence in _iter_searchable(content):
+        if qualified in seen:
+            continue
+        block = extract_function_from_content(content, declaration.name, occurrence)
+        if block is None:
+            continue
+        if all(_identifier_match(token, block) for token in tokens):
+            seen.add(qualified)
+            results.append((declaration.name, qualified, occurrence))
+    return results
 
 
 def _declaration_line(content: str, name: str, occurrence: int = 0) -> int:

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -237,7 +237,7 @@ def _format_results(
     total = len(header)
     for name, block, locations in declarations:
         (primary_path, primary_line), *extra = locations
-        location_header = f"-- {primary_path}:{primary_line}{note}"
+        location_header = f"-- {name} — {primary_path}:{primary_line}{note}"
         if extra:
             also = ", ".join(f"{path}:{line}" for path, line in extra)
             location_header += f" (also: {also})"

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -104,26 +104,14 @@ def _iter_lean_files(root: Path) -> Iterator[Path]:
                 yield Path(dirpath) / filename
 
 
-def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str, int]]:
-    """`(simple_name, qualified_name, occurrence)` for declarations matching `query`.
+def _iter_searchable(content: str):
+    """Yield (declaration, qualified_name, occurrence) for each searchable declaration.
 
-    Matching is case-insensitive against the namespace-QUALIFIED name, so a
-    multi-word query like "BinaryTree insert" matches a `def insert` declared inside
-    `namespace BinaryTree` as well as a top-level `def BinaryTree.insert`. The simple
-    name (as written in source) is returned alongside, since block extraction and line
-    lookup operate on the source text. `occurrence` is the 0-based index of this
-    declaration among all declarations sharing its simple name in the file, so callers
-    can disambiguate the correct block/line when the same simple name appears in several
-    namespaces. Preserves source order, de-duplicated by qualified name.
+    Tracks namespace/section scope to build the qualified name and counts per-simple-name
+    occurrences (aligned with re.finditer order in extract_function_from_content /
+    _declaration_line). Shared by name matching and the body-search fallback.
     """
-    tokens = query.lower().split()
-    if not tokens:
-        return []
-    results: list[tuple[str, str, int]] = []
-    seen: set[str] = set()
     namespace_stack: list[str | None] = []
-    # Count occurrences of each simple name across ALL declarations, so the index aligns
-    # with re.finditer order in extract_function_from_content / _declaration_line.
     name_counts: dict[str, int] = {}
     for declaration in list_all_declarations_in_lean_code(content):
         occurrence = name_counts.get(declaration.name, 0)
@@ -146,12 +134,38 @@ def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str
             qualified = f"{prefix}.{declaration.name}"
         else:
             qualified = declaration.name
+        yield declaration, qualified, occurrence
+
+
+def _matching_declaration_names(content: str, query: str) -> list[tuple[str, str, int]]:
+    """`(simple_name, qualified_name, occurrence)` for declarations matching `query`.
+
+    Matching is case-insensitive against the namespace-QUALIFIED name, so a
+    multi-word query like "BinaryTree insert" matches a `def insert` declared inside
+    `namespace BinaryTree` as well as a top-level `def BinaryTree.insert`. The simple
+    name (as written in source) is returned alongside, since block extraction and line
+    lookup operate on the source text. `occurrence` is the 0-based index of this
+    declaration among all declarations sharing its simple name in the file, so callers
+    can disambiguate the correct block/line when the same simple name appears in several
+    namespaces. Preserves source order, de-duplicated by qualified name.
+    """
+    tokens = query.lower().split()
+    if not tokens:
+        return []
+    results: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    for declaration, qualified, occurrence in _iter_searchable(content):
         if qualified in seen:
             continue
         if all(token in qualified.lower() for token in tokens):
             seen.add(qualified)
             results.append((declaration.name, qualified, occurrence))
     return results
+
+
+def _body_matching_declarations(content: str, query: str) -> list[tuple[str, str, int]]:
+    """Placeholder replaced in Task 3."""
+    return []
 
 
 def _declaration_line(content: str, name: str, occurrence: int = 0) -> int:
@@ -177,6 +191,7 @@ def _format_results(
     query: str,
     declarations: list[tuple[str, str, list[tuple[Path, int]]]],
     config: SearchLeanLocalConfig,
+    body_match: bool = False,
 ) -> str:
     """Render unique declarations, capping by max_results and max_chars.
 
@@ -206,6 +221,54 @@ def _format_results(
     if overflow:
         output += "\n\nAdditional matches (not shown, refine your query): " + ", ".join(overflow)
     return output
+
+
+def _collect_matches(
+    root: Path, query: str, *, body: bool
+) -> list[tuple[str, str, list[tuple[Path, int]]]]:
+    """Scan every .lean file under `root` and group matches by (qualified_name, block).
+
+    `body=False` matches declaration names; `body=True` matches query tokens as whole
+    identifiers inside declaration blocks (the fallback). Identical blocks copied across
+    files collapse to one entry recording every location.
+    """
+    grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
+    for lean_file in _iter_lean_files(root):
+        try:
+            content = lean_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug(f"Skipping unreadable Lean file {lean_file}: {exc}")
+            continue
+        matches = (
+            _body_matching_declarations(content, query)
+            if body
+            else _matching_declaration_names(content, query)
+        )
+        for simple_name, qualified_name, occurrence in matches:
+            block = extract_function_from_content(content, simple_name, occurrence)
+            if block is None:
+                continue
+            line = _declaration_line(content, simple_name, occurrence)
+            grouped.setdefault((qualified_name, block), []).append(
+                (lean_file.relative_to(root), line)
+            )
+    return [(name, block, locations) for (name, block), locations in grouped.items()]
+
+
+def _search_root(
+    root: Path, query: str, config: SearchLeanLocalConfig, *, label: str = "LocalLeanSearch"
+) -> str:
+    """Search `root` by declaration name; fall back to body search only if name finds nothing."""
+    decls = _collect_matches(root, query, body=False)
+    if decls:
+        logger.info(f"{label}: Found {len(decls)} declarations for '{query}' under {root}")
+        return _format_results(query, decls, config)
+    body_decls = _collect_matches(root, query, body=True)
+    if body_decls:
+        logger.info(f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}")
+        return _format_results(query, body_decls, config, body_match=True)
+    logger.info(f"{label}: No results for '{query}'")
+    return f'No declarations matching "{query}" found.'
 
 
 class LocalLeanSearcher:
@@ -252,35 +315,7 @@ class LocalLeanSearcher:
             logger.warning(f"LocalLeanSearch: {error}")
             return error
 
-        # Group by (qualified_name, block): identical declarations copied into several
-        # files collapse to one entry recording every location, preserving first-seen order.
-        grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
-        for lean_file in _iter_lean_files(root):
-            try:
-                content = lean_file.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError) as exc:
-                logger.debug(f"Skipping unreadable Lean file {lean_file}: {exc}")
-                continue
-            for simple_name, qualified_name, occurrence in _matching_declaration_names(
-                content, query
-            ):
-                block = extract_function_from_content(content, simple_name, occurrence)
-                if block is None:
-                    continue
-                line = _declaration_line(content, simple_name, occurrence)
-                grouped.setdefault((qualified_name, block), []).append(
-                    (lean_file.relative_to(root), line)
-                )
-
-        if not grouped:
-            logger.info(f"LocalLeanSearch: No results for '{query}'")
-            return f'No declarations matching "{query}" found.'
-
-        declarations = [(name, block, locations) for (name, block), locations in grouped.items()]
-        logger.info(
-            f"LocalLeanSearch: Found {len(declarations)} declarations for '{query}' under {root}"
-        )
-        return _format_results(query, declarations, self.config)
+        return _search_root(root, query, self.config)
 
 
 class LocalLeanSearchInput(BaseModel):

--- a/tests/unit/tools/test_cslib_search.py
+++ b/tests/unit/tools/test_cslib_search.py
@@ -47,3 +47,159 @@ class TestCslibRegistration:
         tool = await create_tool({"tool_type": "search_cslib"}, base_folder=str(root))
         assert tool is not None
         assert tool.name == "search_cslib_tool"
+
+
+from ax_prover.tools.local_lean_search import LocalLeanSearcher, SearchLeanLocalConfig
+
+# CSLib-shaped content: module header, public import, namespace, doc + own-line @[simp],
+# noncomputable, private. `measure` here collides (different namespace/body) with the SKI file.
+CSLIB_REL = """module
+
+public import Cslib.Init
+
+namespace WellFounded
+
+/-- Transitive-closure well-foundedness. -/
+@[simp]
+theorem ofTransGen (h : True) : True := h
+
+noncomputable def measure : Nat := 0
+
+private theorem secret : True := trivial
+
+end WellFounded
+"""
+
+# Inductive with distinctive constructor names (Iterm is only a constructor, not a decl).
+CSLIB_SKI = """module
+namespace CombinatoryLogic
+
+inductive SKI where
+  | Sterm | Kterm | Iterm
+  | app : SKI -> SKI -> SKI
+
+def measure : SKI -> Nat
+  | _ => 1
+
+end CombinatoryLogic
+"""
+
+
+def _make_rich_cslib(tmp_path, *, with_mathlib=False):
+    root = tmp_path / "proj"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "p"\n')
+    (root / "Challenges" / "Def_Local.lean").write_text("def ProjectOnlyThing : Nat := 0\n")
+    cslib = root / ".lake" / "packages" / "cslib" / "Cslib"
+    cslib.mkdir(parents=True)
+    (cslib / "Relation.lean").write_text(CSLIB_REL)
+    (cslib / "SKI.lean").write_text(CSLIB_SKI)
+    if with_mathlib:
+        mathlib = root / ".lake" / "packages" / "mathlib" / "Mathlib"
+        mathlib.mkdir(parents=True)
+        (mathlib / "X.lean").write_text("def MathlibOnly : Nat := 1\n")
+    return root
+
+
+class TestCslibIsolation:
+    def test_cslib_tool_excludes_project_files(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("ProjectOnlyThing")
+        assert out == 'No declarations matching "ProjectOnlyThing" found.'
+
+    def test_cslib_tool_excludes_sibling_mathlib(self, tmp_path):
+        root = _make_rich_cslib(tmp_path, with_mathlib=True)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("MathlibOnly")
+        assert out == 'No declarations matching "MathlibOnly" found.'
+
+    def test_local_tool_excludes_cslib(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root)).search("ofTransGen")
+        assert out == 'No declarations matching "ofTransGen" found.'
+
+    def test_local_tool_finds_project_file(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root)).search(
+            "ProjectOnlyThing"
+        )
+        assert "def ProjectOnlyThing" in out
+
+
+class TestCslibModuleShapes:
+    def test_own_line_attribute_decl_found_and_block_includes_attr(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+        assert "theorem ofTransGen" in out
+        assert "@[simp]" in out
+
+    def test_module_and_public_import_do_not_create_bogus_results(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("Cslib")
+        assert out == 'No declarations matching "Cslib" found.'
+
+
+class TestCslibNamespaceAndDuplicates:
+    def test_multiword_qualified_query(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search(
+            "WellFounded ofTransGen"
+        )
+        assert "WellFounded.ofTransGen" in out
+
+    def test_duplicate_simple_name_across_files_resolves_distinctly(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("measure")
+        assert "WellFounded.measure" in out
+        assert "CombinatoryLogic.measure" in out
+        assert ":= 0" in out
+        assert "SKI -> Nat" in out
+
+
+class TestCslibModifiers:
+    def test_private_theorem_found(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("secret")
+        assert "WellFounded.secret" in out
+
+    def test_noncomputable_def_found(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("measure")
+        assert "noncomputable def measure" in out
+
+
+class TestCslibBodyAndConstructors:
+    def test_inductive_constructor_found_via_body(self, tmp_path):
+        # `Iterm` is a constructor, not a top-level decl: name search misses, body search hits SKI.
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("Iterm")
+        assert "inductive SKI" in out
+        assert "matched in body" in out
+
+
+class TestCslibEdges:
+    def test_missing_cslib_dir_message(self, tmp_path):
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "lakefile.toml").write_text('name = "p"\n')
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(root)).search("anything")
+        assert "CSLib search unavailable" in out
+        assert ".lake/packages/cslib" in out
+
+    def test_resolves_from_subdirectory_walk_up(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        sub = root / "Challenges"
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(sub)).search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+
+    def test_resolves_from_parent_walk_down(self, tmp_path):
+        _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(), base_folder=str(tmp_path)).search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+
+    def test_caps_overflow_lists_extras(self, tmp_path):
+        root = _make_rich_cslib(tmp_path)
+        out = CslibSearcher(SearchCslibConfig(max_results=1), base_folder=str(root)).search(
+            "measure"
+        )
+        assert "Additional matches" in out

--- a/tests/unit/tools/test_cslib_search.py
+++ b/tests/unit/tools/test_cslib_search.py
@@ -1,0 +1,49 @@
+"""Unit tests for the CSLib search tool."""
+
+import pytest
+
+from ax_prover.tools import create_search_cslib_tool
+from ax_prover.tools.cslib_search import (
+    CSLIB_SEARCH_TOOL_TYPE,
+    CslibSearcher,
+    SearchCslibConfig,
+)
+from ax_prover.tools.registry import TOOL_REGISTRY, create_tool
+
+
+def _make_project_with_cslib(tmp_path):
+    """A lake project whose .lake/packages/cslib holds one namespaced theorem."""
+    root = tmp_path / "proj"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "p"\n')
+    (root / "Challenges" / "Def_Local.lean").write_text("def ProjectOnlyThing : Nat := 0\n")
+    cslib = root / ".lake" / "packages" / "cslib" / "Cslib"
+    cslib.mkdir(parents=True)
+    (cslib / "Relation.lean").write_text(
+        "namespace WellFounded\n\ntheorem ofTransGen (h : True) : True := h\n\nend WellFounded\n"
+    )
+    return root
+
+
+class TestCslibBasic:
+    def test_finds_namespaced_theorem_qualified(self, tmp_path):
+        root = _make_project_with_cslib(tmp_path)
+        searcher = CslibSearcher(SearchCslibConfig(), base_folder=str(root))
+        out = searcher.search("ofTransGen")
+        assert "WellFounded.ofTransGen" in out
+        assert "theorem ofTransGen" in out
+
+    def test_tool_type_constant(self):
+        assert CSLIB_SEARCH_TOOL_TYPE == "search_cslib"
+
+
+class TestCslibRegistration:
+    def test_registered_in_registry(self):
+        assert CSLIB_SEARCH_TOOL_TYPE in TOOL_REGISTRY
+
+    @pytest.mark.asyncio
+    async def test_create_tool_builds_named_tool(self, tmp_path):
+        root = _make_project_with_cslib(tmp_path)
+        tool = await create_tool({"tool_type": "search_cslib"}, base_folder=str(root))
+        assert tool is not None
+        assert tool.name == "search_cslib_tool"

--- a/tests/unit/tools/test_cslib_search.py
+++ b/tests/unit/tools/test_cslib_search.py
@@ -2,12 +2,12 @@
 
 import pytest
 
-from ax_prover.tools import create_search_cslib_tool
 from ax_prover.tools.cslib_search import (
     CSLIB_SEARCH_TOOL_TYPE,
     CslibSearcher,
     SearchCslibConfig,
 )
+from ax_prover.tools.local_lean_search import LocalLeanSearcher, SearchLeanLocalConfig
 from ax_prover.tools.registry import TOOL_REGISTRY, create_tool
 
 
@@ -48,8 +48,6 @@ class TestCslibRegistration:
         assert tool is not None
         assert tool.name == "search_cslib_tool"
 
-
-from ax_prover.tools.local_lean_search import LocalLeanSearcher, SearchLeanLocalConfig
 
 # CSLib-shaped content: module header, public import, namespace, doc + own-line @[simp],
 # noncomputable, private. `measure` here collides (different namespace/body) with the SKI file.

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -497,3 +497,31 @@ class TestBodyMatchingDeclarations:
     def test_body_search_respects_identifier_boundary(self):
         # 'quer' is a prefix, not a whole identifier in the body -> no match.
         assert _body_matching_declarations(WHERE_BLOCK_LEAN, "quer") == []
+
+
+@pytest.fixture
+def where_project(tmp_path):
+    root = tmp_path / "proj"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "p"\n')
+    (root / "Challenges" / "Q.lean").write_text(WHERE_BLOCK_LEAN)
+    return root
+
+
+class TestBodySearchEndToEnd:
+    def test_search_falls_back_to_body_for_where_helper(self, where_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        out = searcher.search("query_aux")
+        assert "def query" in out
+        assert "matched in body" in out
+        assert "Challenges/Q.lean:" in out
+
+    def test_name_match_does_not_use_body_fallback(self, where_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        out = searcher.search("query")
+        assert "def query" in out
+        assert "matched in body" not in out
+
+    def test_no_match_message_unchanged(self, where_project):
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        assert searcher.search("zzz_nope") == 'No declarations matching "zzz_nope" found.'

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -12,7 +12,9 @@ from ax_prover.tools.local_lean_search import (
     SEARCHABLE_TYPES,
     LocalLeanSearcher,
     SearchLeanLocalConfig,
+    _body_matching_declarations,
     _declaration_line,
+    _identifier_match,
     _iter_lean_files,
     _matching_declaration_names,
     _walk_down_for_roots,
@@ -453,3 +455,19 @@ class TestAmbiguousSimpleName:
         assert ":= BBB" in result
         assert "Challenges/Dup.lean:3" in result  # A.insert
         assert "Challenges/Dup.lean:9" in result  # B.insert
+
+
+class TestIdentifierMatch:
+    def test_matches_standalone_identifier(self):
+        assert _identifier_match("query_aux", "  x := query_aux n 0")
+
+    def test_not_matched_inside_longer_identifier(self):
+        # trailing 'N' continues the identifier, so it is not a whole-identifier match
+        assert not _identifier_match("query_aux", "def query_auxN := 1")
+
+    def test_dot_is_an_identifier_boundary_char(self):
+        # '.' is part of a Lean identifier, so "insert" does NOT match inside "Treap.insert"
+        assert not _identifier_match("insert", "y := Treap.insert t")
+
+    def test_case_insensitive(self):
+        assert _identifier_match("foo", "exact FOO")

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -487,9 +487,7 @@ class TestBodyMatchingDeclarations:
         assert _matching_declaration_names(WHERE_BLOCK_LEAN, "query_aux") == []
 
     def test_body_search_returns_enclosing_declaration(self):
-        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux") == [
-            ("query", "query", 0)
-        ]
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux") == [("query", "query", 0)]
 
     def test_body_search_requires_all_tokens(self):
         assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux missing") == []

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -471,3 +471,29 @@ class TestIdentifierMatch:
 
     def test_case_insensitive(self):
         assert _identifier_match("foo", "exact FOO")
+
+
+WHERE_BLOCK_LEAN = """import Mathlib
+
+def query (n : Nat) : Nat :=
+  query_aux n 0   where query_aux (j acc : Nat) : Nat :=
+    if j = 0 then acc else query_aux (j - 1) (acc + j)
+"""
+
+
+class TestBodyMatchingDeclarations:
+    def test_name_search_misses_where_helper(self):
+        # `query_aux` is not a top-level declaration, so name search returns nothing.
+        assert _matching_declaration_names(WHERE_BLOCK_LEAN, "query_aux") == []
+
+    def test_body_search_returns_enclosing_declaration(self):
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux") == [
+            ("query", "query", 0)
+        ]
+
+    def test_body_search_requires_all_tokens(self):
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "query_aux missing") == []
+
+    def test_body_search_respects_identifier_boundary(self):
+        # 'quer' is a prefix, not a whole identifier in the body -> no match.
+        assert _body_matching_declarations(WHERE_BLOCK_LEAN, "quer") == []


### PR DESCRIPTION
Adds two capabilities to the local Lean search, plus tests, per the design spec (`docs/superpowers/specs/2026-06-05-local-search-coverage-and-cslib-design.md`).

## 1. Body-search fallback
When a query matches no declaration **name**, the search now matches query tokens as **whole identifiers** inside declaration bodies and returns the enclosing declaration (flagged `(matched in body)`). This finds `where`/`let rec` helpers like `query_aux` and any other body identifier — no fragile syntax parsing. Lives in a shared `_search_root` extracted from `LocalLeanSearcher`.

## 2. `search_cslib` tool
New tool that resolves `<project>/.lake/packages/cslib` relative to the lake root (no hardcoded path) and reuses `_search_root` (inheriting the body fallback). Wired into the bundled `tools.yaml` / `default.yaml`. Results now also show the namespace-qualified name in the header.

## Tests
- Body-search unit + integration tests.
- Tricky CSLib retrieval matrix: isolation (cslib-only vs sibling mathlib vs project), Lean module-system shapes (`module`/`public import`/own-line `@[simp]`), namespace qualification + cross-file duplicate simple names, modifiers (`noncomputable`/`private`), body-search + inductive constructors, and edges (missing dir, walk-up/down, caps overflow).
- Full suite: 332 passing. Verified end-to-end against the real AI4Math dataset (`query_aux`, CSLib `WellFounded`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how search results are formatted and when matches are returned (body fallback), which can shift proposer behavior; scope is tool-layer only with broad unit tests and no security-sensitive paths.
> 
> **Overview**
> **Local Lean search** now shares a `_search_root` pipeline: declaration **name** search runs first; if nothing matches, it falls back to **body** search (whole-identifier tokens inside declaration blocks) and labels hits with `(matched in body)`. Result headers also show the qualified name (`-- name — path:line`).
> 
> A new **`search_cslib`** proposer tool resolves `.lake/packages/cslib` from the Lake root and reuses the same search logic (including body fallback), wired through `tools.yaml`, `default.yaml`, and tool exports.
> 
> Unit tests cover body-search edge cases and a CSLib retrieval matrix (isolation vs project/mathlib, module shapes, duplicates, modifiers, constructors). Design/plan docs are added; Lean **4.28** prompt updates are explicitly out of scope (separate PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07850edfb59b4e4a58b136bf8fa03b691bb939a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->