### PR TITLE
prompts: target Lean 4.28

### DIFF
--- a/src/ax_prover/prover/prompts.py
+++ b/src/ax_prover/prover/prompts.py
@@ -3,7 +3,7 @@ You are an LLM acting as a Lean 4 proof expert in an ITERATIVE proof development
 
 ## Your Role
 
-Your task is to propose the next iteration of a Lean 4 proof (Lean version 4.24). Your code will be compiled with `lake build`, and the results (successes, errors, remaining goals) will inform the next iteration.
+Your task is to propose the next iteration of a Lean 4 proof (Lean version 4.28). Your code will be compiled with `lake build`, and the results (successes, errors, remaining goals) will inform the next iteration.
 Think carefully about the current proof state and the knowledge gathered from the previous attempt to make as much progress as possible with this new attempt.
 
 **CRITICAL: While you do NOT need to produce a complete working proof in a single attempt, you DO NEED to submit a final full proof regardless of the difficulty and the time it takes to complete it. NEVER give up, if something is complex, break it down into manageable steps, sketch out the proof structure, and work relentlessly to solve it. You can prove everything that will be given to you.**
@@ -124,7 +124,7 @@ PROPOSER_SYSTEM_PROMPT_SINGLE_SHOT = """
 You are an LLM acting as a Lean 4 proof expert in a SINGLE-SHOT process.
 
 # Your Role
-Your task is to propose a complete and valid Lean 4 proof (Lean version 4.24). Your code will be checked with `lake build`, although you will not be able to see the build result nor receive any feedback.
+Your task is to propose a complete and valid Lean 4 proof (Lean version 4.28). Your code will be checked with `lake build`, although you will not be able to see the build result nor receive any feedback.
 You can use the tools provided to you to help you with your task.
 
 **CRITICAL: You MUST produce a complete proof in this single attempt without any placeholder (like `sorry` or `admit`). You DO NEED to submit a final full proof regardless of the difficulty and the time it takes to complete it. NEVER give up, if something is complex, break it down into manageable steps, and think about the proof structure before writing it. You can prove everything that will be given to you.**


### PR DESCRIPTION
The proposer prompts stated "Lean version 4.24"; the AI4Math/Codabench dataset requires Lean 4.28.0. Updates both the iterative and single-shot proposer system prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prompt text change with no runtime or security impact.
> 
> **Overview**
> Updates the **Lean version** stated in the proposer system prompts from **4.24** to **4.28** in `prompts.py`, for both the **iterative** (`PROPOSER_SYSTEM_PROMPT`) and **single-shot** (`PROPOSER_SYSTEM_PROMPT_SINGLE_SHOT`) flows. No proof logic, tactics, or output schema changes—only the version string the model is told to target when generating proofs via `lake build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd11e080d9a304ca4862508e865a2f7d490e0e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->