### PR TITLE
feat: route lemma search to the tool matching the file's imports

### DIFF
--- a/src/ax_prover/prover/prompts.py
+++ b/src/ax_prover/prover/prompts.py
@@ -31,7 +31,7 @@ Think carefully about the current proof state and the knowledge gathered from th
 
 3. **Quality Standards**
     - Use appropriate Lean 4 tactics and syntax
-    - Reference Mathlib lemmas when applicable
+    - When searching for lemmas, match the search tool to the file's imports: if the file imports `Mathlib.*`, use the Mathlib search tool (`search_lean_search_tool`); if it imports `Cslib.*`, use the CSLib search tool (`search_cslib_tool`); for declarations from the project's own modules (any other local imports, neither Mathlib nor CSLib), use the local project search tool (`search_lean_local_tool`).
     - Add imports as needed for any lemmas or tactics you use
 </requirements>
 
@@ -141,7 +141,7 @@ You can use the tools provided to you to help you with your task.
 
 3. **Quality Standards**
     - Use appropriate Lean 4 tactics and syntax
-    - Reference Mathlib lemmas when applicable
+    - When searching for lemmas, match the search tool to the file's imports: if the file imports `Mathlib.*`, use the Mathlib search tool (`search_lean_search_tool`); if it imports `Cslib.*`, use the CSLib search tool (`search_cslib_tool`); for declarations from the project's own modules (any other local imports, neither Mathlib nor CSLib), use the local project search tool (`search_lean_local_tool`).
     - Add imports as needed for any lemmas or tactics you use
 </requirements>
 


### PR DESCRIPTION
Replaces the generic "Reference Mathlib lemmas when applicable" nudge in both proposer system prompts (iterative + single-shot) with explicit routing guidance: pick the search tool by which library the file imports —

- `Mathlib.*` → `search_lean_search_tool`
- `Cslib.*` → `search_cslib_tool`
- other / local-project imports → `search_lean_local_tool`

Based on `local-lean-search-tool` because the routing references the CSLib and local-project search tools introduced there. Pure prompt-text change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only guidance in two strings; no execution path or security-sensitive logic changes.
> 
> **Overview**
> Both **iterative** and **single-shot** proposer system prompts in `prompts.py` now tell the model how to pick a lemma search tool from the file’s imports, instead of only nudging Mathlib use.
> 
> Under **Quality Standards**, the old line *“Reference Mathlib lemmas when applicable”* is replaced with explicit routing: `Mathlib.*` → `search_lean_search_tool`, `Cslib.*` → `search_cslib_tool`, other local imports → `search_lean_local_tool`. No runtime or tool wiring changes—prompt text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2291c974eb0f60ec0ea691d33970ad1b55d2073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->