### PR TITLE
fix: address code-review findings on the experiment branch

### DIFF
--- a/src/ax_prover/models/messages.py
+++ b/src/ax_prover/models/messages.py
@@ -165,12 +165,25 @@ class SorriesGoalStateFeedback(FeedbackMessage):
     feedback_type: Literal["sorries_goal_state"] = "sorries_goal_state"
     sorry_count: int
     goal_state_at_sorries: str
+    dropped_preamble_warning: str = ""
     is_success: bool = False
 
-    def __init__(self, sorry_count: int, goal_state_at_sorries: str, **kwargs):
-        """Initialize with formatted sorries goal state message."""
+    def __init__(
+        self,
+        sorry_count: int,
+        goal_state_at_sorries: str,
+        dropped_preamble_warning: str = "",
+        **kwargs,
+    ):
+        """Initialize with formatted sorries goal state message.
+
+        `dropped_preamble_warning`, when non-empty, is prepended so the proposer is told
+        its proposed imports/opens were dropped even though the build succeeded.
+        """
         kwargs.pop("content", None)
+        warning_prefix = f"{dropped_preamble_warning}\n\n" if dropped_preamble_warning else ""
         content = (
+            f"{warning_prefix}"
             f"SORRIES DETECTED: The proposed code contains {sorry_count} sorry/admit. "
             f"Work on closing these sorries. Here is the Goal State at these sorries {goal_state_at_sorries} ."
         )
@@ -178,6 +191,7 @@ class SorriesGoalStateFeedback(FeedbackMessage):
             content=content,
             sorry_count=sorry_count,
             goal_state_at_sorries=goal_state_at_sorries,
+            dropped_preamble_warning=dropped_preamble_warning,
             **kwargs,
         )
 

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -67,6 +67,12 @@ from .prompts import (
     build_proposer_system_prompt,
 )
 
+# Conservative fallback context window (Claude-class) used only when the model's
+# langchain profile reports no `max_input_tokens` (e.g. a very new release langchain
+# doesn't know yet). When this fires it is logged as a warning so the misconfiguration
+# is visible rather than silently masked.
+DEFAULT_MAX_INPUT_TOKENS = 200_000
+
 
 def _dropped_preamble_warning(
     restrict_to_proof_body: bool,
@@ -128,11 +134,23 @@ class ProverAgent:
         summary_llm_config = self.config.summarize_output.llm or self.config.prover_llm
         self.summary_llm_client = LLMClient(summary_llm_config)
 
-        # New models (e.g. claude-opus-4-8) may have no langchain profile / no
-        # max_input_tokens; fall back to the standard Claude context window.
-        self.max_input_tokens = self.llm_client.profile.get("max_input_tokens") or 200_000
+        # New models may have no langchain profile / no max_input_tokens. Rather than
+        # silently substituting a default for any falsy value (which would over- or
+        # under-estimate the real window for non-Claude models), log a warning naming
+        # the model and the fallback used so the misconfiguration is visible.
+        profile_max = self.llm_client.profile.get("max_input_tokens")
+        if not profile_max:
+            self.logger.warning(
+                f"No max_input_tokens in profile for model {self.llm_client.model_id}; "
+                f"falling back to {DEFAULT_MAX_INPUT_TOKENS}."
+            )
+            profile_max = DEFAULT_MAX_INPUT_TOKENS
+        self.max_input_tokens = profile_max
         if self.max_input_tokens < 1000:
-            self.logger.error("Error: max_input_tokens abnormally small")
+            self.logger.error(
+                f"max_input_tokens abnormally small ({self.max_input_tokens}) for model "
+                f"{self.llm_client.model_id}."
+            )
 
     # TODO: this is creating extra confusion. But we require some things to be run asynchronously
     @classmethod

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -428,6 +428,17 @@ class ProverAgent:
             if build_success:
                 self.logger.info("Build successful")
 
+                # Imports/opens proposed under a locked file are dropped even when the
+                # build succeeds (import redundant / open unnecessary). Surface this on
+                # the iterative path so the proposer is not implicitly taught they worked.
+                preamble_warning = _dropped_preamble_warning(
+                    self.config.restrict_to_proof_body,
+                    state.last_proposal.imports,
+                    state.last_proposal.opens,
+                )
+                if preamble_warning:
+                    self.logger.info(preamble_warning)
+
                 if sorry_count := count_pattern(
                     state.last_proposal.code, pattern=r"\b(sorry|admit)\b"
                 )[0]:
@@ -440,6 +451,7 @@ class ProverAgent:
                     feedback = SorriesGoalStateFeedback(
                         sorry_count=sorry_count,
                         goal_state_at_sorries=goal_state_at_sorries,
+                        dropped_preamble_warning=preamble_warning,
                     )
                     return {"messages": [feedback]}
 

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -47,6 +47,7 @@ from ..utils.git import get_repo_metadata
 from ..utils.lean_interact import get_goal_state_at_sorries
 from ..utils.lean_parsing import (
     SEARCH_TACTIC_PATTERN,
+    blank_string_literals,
     find_declaration_by_name,
     find_stripped_declaration_names,
     list_all_declarations_in_lean_code,
@@ -424,7 +425,9 @@ class ProverAgent:
                     )
                     return {"messages": [feedback]}
 
-                stripped_code = strip_comments(state.last_proposal.code)
+                # Blank string-literal contents so a tactic-like substring or the word
+                # "axiom" inside a string/docstring cannot falsely trigger the checks below.
+                stripped_code = blank_string_literals(strip_comments(state.last_proposal.code))
 
                 axiom_count, axiom_locations = count_pattern(stripped_code, pattern=r"\baxiom\b")
                 if axiom_count:

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -268,22 +268,30 @@ def _format_results(
     return output
 
 
-def _collect_matches(
-    root: Path, query: str, *, body: bool
-) -> list[tuple[str, str, list[tuple[Path, int]]]]:
-    """Scan every .lean file under `root` and group matches by (qualified_name, block).
-
-    `body=False` matches declaration names; `body=True` matches query tokens as whole
-    identifiers inside declaration blocks (the fallback). Identical blocks copied across
-    files collapse to one entry recording every location.
-    """
-    grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
+def _read_lean_files(root: Path) -> list[tuple[Path, str]]:
+    """Walk `root` once, returning (relative_path, content) for each readable .lean file."""
+    files: list[tuple[Path, str]] = []
     for lean_file in _iter_lean_files(root):
         try:
             content = lean_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             logger.debug(f"Skipping unreadable Lean file {lean_file}: {exc}")
             continue
+        files.append((lean_file.relative_to(root), content))
+    return files
+
+
+def _collect_matches(
+    files: list[tuple[Path, str]], query: str, *, body: bool
+) -> list[tuple[str, str, list[tuple[Path, int]]]]:
+    """Group matches across already-read files by (qualified_name, block).
+
+    `body=False` matches declaration names; `body=True` matches query tokens as whole
+    identifiers inside declaration blocks (the fallback). Identical blocks copied across
+    files collapse to one entry recording every location.
+    """
+    grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
+    for relative_path, content in files:
         matches = (
             _body_matching_declarations(content, query)
             if body
@@ -294,21 +302,24 @@ def _collect_matches(
             if block is None:
                 continue
             line = _declaration_line(content, simple_name, occurrence)
-            grouped.setdefault((qualified_name, block), []).append(
-                (lean_file.relative_to(root), line)
-            )
+            grouped.setdefault((qualified_name, block), []).append((relative_path, line))
     return [(name, block, locations) for (name, block), locations in grouped.items()]
 
 
 def _search_root(
     root: Path, query: str, config: SearchLeanLocalConfig, *, label: str = "LocalLeanSearch"
 ) -> str:
-    """Search `root` by declaration name; fall back to body search only if name finds nothing."""
-    decls = _collect_matches(root, query, body=False)
+    """Search `root` by declaration name; fall back to body search only if name finds nothing.
+
+    Walks the tree and reads each file once; the body fallback reuses the cached contents
+    rather than re-walking and re-reading on a name-miss.
+    """
+    files = _read_lean_files(root)
+    decls = _collect_matches(files, query, body=False)
     if decls:
         logger.info(f"{label}: Found {len(decls)} declarations for '{query}' under {root}")
         return _format_results(query, decls, config)
-    body_decls = _collect_matches(root, query, body=True)
+    body_decls = _collect_matches(files, query, body=True)
     if body_decls:
         logger.info(f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}")
         return _format_results(query, body_decls, config, body_match=True)

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -231,6 +231,7 @@ def _format_results(
     entry and the rest are listed in an "(also: …)" suffix. Overflow (beyond the
     caps) is listed by name.
     """
+    truncation_marker = "\n-- … (truncated; refine your query for the full declaration)"
     header = f'Found {len(declarations)} declaration(s) matching "{query}":'
     note = " (matched in body)" if body_match else ""
     shown: list[str] = []
@@ -247,6 +248,18 @@ def _format_results(
         if len(shown) < config.max_results and within_budget:
             shown.append(entry)
             total += len(entry) + 2
+        elif not shown:
+            # The most-relevant match alone exceeds the budget: truncate its block to the
+            # remaining space rather than dropping it entirely (which would leave the user
+            # with a header and a "not shown" note but no source). Keep the full location
+            # header and at least one character of the block body so the source is visible.
+            available_for_block = (
+                config.max_chars - total - 2 - len(location_header) - 1 - len(truncation_marker)
+            )
+            kept = block[: max(available_for_block, 1)]
+            truncated = f"{location_header}\n{kept}{truncation_marker}"
+            shown.append(truncated)
+            total += len(truncated) + 2
         else:
             overflow.append(f"{name} ({primary_path}:{primary_line})")
     output = header + "\n\n" + "\n\n".join(shown)

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -22,6 +22,7 @@ from ..utils.lean_parsing import (
     LEAN_KEYWORDS,
     extract_function_from_content,
     list_all_declarations_in_lean_code,
+    non_comment_matches,
 )
 from .registry import register_tool, tool_name_from_type
 
@@ -206,7 +207,7 @@ def _declaration_line(content: str, name: str, occurrence: int = 0) -> int:
     line. Falls back to 1 if the declaration keyword cannot be located.
     """
     pattern = rf"^\s*{DECL_PREFIX}(?:{_KEYWORDS_PATTERN})\s+{re.escape(name)}{DECL_NAME_END}"
-    matches = list(re.finditer(pattern, content, re.MULTILINE))
+    matches = non_comment_matches(pattern, content)
     if occurrence >= len(matches):
         return 1
     match = matches[occurrence]

--- a/src/ax_prover/utils/build.py
+++ b/src/ax_prover/utils/build.py
@@ -14,7 +14,7 @@ from ..config import LeanConfig
 from ..models.files import Location
 from ..utils import get_logger
 from ..utils.files import edit_function, edit_imports, edit_opens, read_file
-from ..utils.lean_parsing import extract_function_from_content
+from ..utils.lean_parsing import extract_function_from_content, resolve_target_occurrence
 
 if TYPE_CHECKING:
     from ax_prover.models.messages import ProposalMessage
@@ -434,9 +434,19 @@ class TemporaryProposal:
                         return self
 
             if self.proposal.code:
-                # Only allow edits within the function definition
+                # Only allow edits within the function definition. Resolve the correct
+                # occurrence of the target (the proposal may contain several declarations
+                # sharing the target's simple name, e.g. `A.insert` and `B.insert`); fall
+                # back to the first occurrence when resolution is ambiguous or finds nothing
+                # so the common single-declaration case is unchanged.
+                resolved = resolve_target_occurrence(self.proposal.code, self.location.name)
+                if resolved is not None:
+                    simple_name, occurrence = resolved
+                else:
+                    simple_name = self.location.name
+                    occurrence = 0
                 filtered_code = extract_function_from_content(
-                    self.proposal.code, self.location.name
+                    self.proposal.code, simple_name, occurrence
                 )
                 success = edit_function(self.base_folder, self.location, filtered_code)
                 if not success:

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -179,6 +179,39 @@ def strip_comments(src: str) -> str:
     return "".join(out)
 
 
+# A command prefix that binds to the following declaration ends with a standalone `in`
+# keyword (e.g. `open Nat in`, `set_option foo true in`, `variable (x) in`). The negative
+# lookbehind `(?<![\w.])` ensures we match the keyword `in`, not the tail of an identifier
+# like `Fin` or `min`.
+_IN_PREFIX_LINE = re.compile(r"(?<![\w.])in[ \t]*$")
+
+
+def _extend_start_over_in_prefixes(content: str, start_pos: int) -> int:
+    """Move start_pos back over contiguous preceding `... in` command-prefix lines.
+
+    Stops at a blank line or any line that is not an `... in` prefix, so ordinary
+    preceding declarations and comments are never absorbed.
+    """
+    # start_pos may sit on leading whitespace (the matcher's `\s*` can span blank lines),
+    # so advance to the first non-blank line — the real start of the declaration block.
+    while start_pos < len(content) and content[start_pos] in " \t\n":
+        start_pos += 1
+
+    line_start = content.rfind("\n", 0, start_pos) + 1
+    while line_start > 0:
+        # The line above the current block (without its trailing newline).
+        prev_line_end = line_start - 1
+        prev_line_start = content.rfind("\n", 0, prev_line_end) + 1
+        prev_line = content[prev_line_start:prev_line_end]
+
+        if not prev_line.strip() or not _IN_PREFIX_LINE.search(prev_line.rstrip()):
+            break
+
+        line_start = prev_line_start
+
+    return line_start
+
+
 def extract_function_from_content(
     content: str, function_name: str, occurrence: int = 0
 ) -> str | None:
@@ -216,6 +249,13 @@ def extract_function_from_content(
         if not re.search(rf"\b(?:{keywords_pattern})\s+\w+", between):
             start_pos = doc_match.start()
             break
+
+    # Include any contiguous command-prefix lines that bind to this declaration via a
+    # trailing `in` (e.g. `open Nat in`, `set_option ... in`). Without them the bound
+    # command is lost when the block is applied -> "unknown identifier". Walk backward
+    # over preceding lines that end in a standalone ` in` token, stopping at a blank line
+    # or any other line (ordinary decls, comments) so we never absorb unrelated code.
+    start_pos = _extend_start_over_in_prefixes(content, start_pos)
 
     # Find next definition, doc comment, structural keyword, or top-level comment
     # at same or lower indentation. The next declaration may itself carry an

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -16,6 +16,26 @@ logger = get_logger(__name__)
 # Lean keywords for declarations
 LEAN_KEYWORDS = [d.value for d in DeclarationType]
 
+# Declaration types that introduce a real, keepable named declaration (the kind that
+# `TemporaryProposal` would strip if it is not the target). Structural/non-declaration
+# entries (Import, Namespace, Section, End, Open, Notation, syntax/macro/elab, ...) are
+# excluded: they are not standalone declarations and stripping them is not the concern.
+STRIPPABLE_DECLARATION_TYPES = frozenset(
+    {
+        DeclarationType.Definition,
+        DeclarationType.Theorem,
+        DeclarationType.Lemma,
+        DeclarationType.Instance,
+        DeclarationType.Structure,
+        DeclarationType.Class,
+        DeclarationType.Inductive,
+        DeclarationType.Axiom,
+        DeclarationType.Abbrev,
+        DeclarationType.NoncomputableDef,
+        DeclarationType.NoncomputableAbbrev,
+    }
+)
+
 # Assertion that a declaration name has ended. A name token runs until whitespace or
 # one of these delimiters (matching list_all_declarations_in_lean_code's name pattern).
 # Use this after a name instead of `\b`: `\b` treats `.` as a boundary, so "Treap" would
@@ -223,7 +243,7 @@ def find_stripped_declaration_names(raw_code: str, target_name: str) -> list[str
     return [
         d.name
         for d in declarations
-        if d.name != target_name and d.declaration_type != DeclarationType.Import
+        if d.name != target_name and d.declaration_type in STRIPPABLE_DECLARATION_TYPES
     ]
 
 

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -179,6 +179,97 @@ def strip_comments(src: str) -> str:
     return "".join(out)
 
 
+def comment_spans(src: str) -> list[tuple[int, int]]:
+    """Character spans (start, end) of every Lean comment region in `src`.
+
+    Mirrors `strip_comments`' state machine — handles `--` line comments, nested
+    `/- … -/` block comments, and leaves string literals intact — but records each
+    comment's character range instead of deleting it. Used to filter out declaration
+    keyword matches that fall inside a comment, so raw-content matching agrees with
+    the comment-stripped enumeration in `list_all_declarations_in_lean_code`.
+    """
+
+    class ParsingState(Enum):
+        Out = 1
+        LineComment = 2
+        BlockComment = 3
+        StringLiteral = 4
+
+    state = ParsingState.Out
+    i = 0
+    depth = 0
+    n = len(src)
+    spans: list[tuple[int, int]] = []
+    comment_start = 0
+
+    while i < n:
+        c = src[i]
+        c2 = src[i : i + 2]
+
+        if state == ParsingState.Out:
+            if c == '"':
+                state = ParsingState.StringLiteral
+                i += 1
+            elif c2 == "--":
+                state = ParsingState.LineComment
+                comment_start = i
+                i += 2
+            elif c2 == "/-":
+                state = ParsingState.BlockComment
+                depth = 1
+                comment_start = i
+                i += 2
+            else:
+                i += 1
+
+        elif state == ParsingState.LineComment:
+            if c == "\n":
+                spans.append((comment_start, i))
+                state = ParsingState.Out
+            i += 1
+
+        elif state == ParsingState.BlockComment:
+            if c2 == "/-":
+                depth += 1
+                i += 2
+            elif c2 == "-/":
+                depth -= 1
+                i += 2
+                if depth == 0:
+                    spans.append((comment_start, i))
+                    state = ParsingState.Out
+            else:
+                i += 1
+
+        elif state == ParsingState.StringLiteral:
+            if c == '"':
+                state = ParsingState.Out
+            i += 1
+
+    # An unterminated line/block comment runs to end-of-input.
+    if state in (ParsingState.LineComment, ParsingState.BlockComment):
+        spans.append((comment_start, n))
+
+    return spans
+
+
+def _in_any_span(offset: int, spans: list[tuple[int, int]]) -> bool:
+    """True if `offset` falls within any (start, end) span (end-exclusive)."""
+    return any(start <= offset < end for start, end in spans)
+
+
+def non_comment_matches(pattern: str, content: str) -> list[re.Match[str]]:
+    """`re.finditer(pattern, content, re.MULTILINE)` matches not starting inside a comment.
+
+    Keeps raw-content occurrence indexing aligned with the comment-stripped
+    enumeration in `list_all_declarations_in_lean_code`, which ignores commented decls.
+    """
+    spans = comment_spans(content)
+    return [
+        m for m in re.finditer(pattern, content, re.MULTILINE) if not _in_any_span(m.start(), spans)
+    ]
+
+
 # A command prefix that binds to the following declaration ends with a standalone `in`
 # keyword (e.g. `open Nat in`, `set_option foo true in`, `variable (x) in`). The negative
 # lookbehind `(?<![\w.])` ensures we match the keyword `in`, not the tail of an identifier
@@ -230,7 +321,7 @@ def extract_function_from_content(
     keywords_pattern = "|".join(LEAN_KEYWORDS)
     pattern = rf"^(\s*){DECL_PREFIX}(?:{_KEYWORDS_ALT})\s+{re.escape(function_name)}{DECL_NAME_END}"
 
-    matches = list(re.finditer(pattern, content, re.MULTILINE))
+    matches = non_comment_matches(pattern, content)
     if occurrence >= len(matches):
         return None
     match = matches[occurrence]

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -364,6 +364,69 @@ def extract_function_from_content(
     return content[start_pos:end_pos].strip()
 
 
+def _iter_namespaced_declarations(content: str):
+    """Yield (declaration, qualified_name, occurrence) for each named declaration.
+
+    Tracks namespace/section scope to build each declaration's namespace-qualified name
+    and counts per-simple-name occurrences (aligned with `extract_function_from_content`'s
+    re.finditer ordering). This mirrors the namespace-aware enumeration in
+    `tools.local_lean_search._iter_searchable`; it lives here so both the search tool and
+    `utils.build` can resolve a target without `utils` importing from `tools` (which would
+    create a circular / layering dependency).
+    """
+    namespace_stack: list[str | None] = []
+    name_counts: dict[str, int] = {}
+    for declaration in list_all_declarations_in_lean_code(content):
+        occurrence = name_counts.get(declaration.name, 0)
+        name_counts[declaration.name] = occurrence + 1
+        declaration_type = declaration.declaration_type
+        if declaration_type == DeclarationType.Namespace:
+            namespace_stack.append(declaration.name)
+            continue
+        if declaration_type == DeclarationType.Section:
+            namespace_stack.append(None)  # sections do not contribute to the name
+            continue
+        if declaration_type == DeclarationType.End:
+            if namespace_stack:
+                namespace_stack.pop()
+            continue
+        if declaration_type not in STRIPPABLE_DECLARATION_TYPES:
+            continue
+        prefix = ".".join(part for part in namespace_stack if part)
+        if prefix and not declaration.name.startswith(f"{prefix}."):
+            qualified = f"{prefix}.{declaration.name}"
+        else:
+            qualified = declaration.name
+        yield declaration, qualified, occurrence
+
+
+def resolve_target_occurrence(content: str, target_name: str) -> tuple[str, int] | None:
+    """Resolve `target_name` to the `(simple_name, occurrence)` of its declaration in `content`.
+
+    `target_name` may be namespace-qualified (`Treap.insert`) or simple (`insert`). The
+    namespace-qualified name of each declaration is computed (tracking `namespace`/`section`
+    scope), then a match is sought where the qualified name equals `target_name`, or — for a
+    simple `target_name` — where the qualified name equals it or ends with `.<target_name>`.
+
+    `occurrence` is the 0-based index among declarations sharing the SIMPLE name, suitable
+    for passing to `extract_function_from_content`.
+
+    Returns None when there is no match or the match is ambiguous (more than one distinct
+    declaration matches), so callers can fall back to the conservative occurrence-0 default.
+    """
+    matches: list[tuple[str, int]] = []
+    is_qualified = "." in target_name
+    for declaration, qualified, occurrence in _iter_namespaced_declarations(content):
+        if qualified == target_name:
+            matches.append((declaration.name, occurrence))
+        elif not is_qualified and qualified.endswith(f".{target_name}"):
+            matches.append((declaration.name, occurrence))
+
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
 def find_stripped_declaration_names(raw_code: str, target_name: str) -> list[str]:
     """Names of top-level declarations that would be stripped when applying a proposal.
 

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -179,6 +179,81 @@ def strip_comments(src: str) -> str:
     return "".join(out)
 
 
+def blank_string_literals(src: str) -> str:
+    """Replace the CONTENTS of string literals with spaces, preserving the quotes.
+
+    Same state machine as `strip_comments` but inverted: comments are left intact while
+    the inside of `"..."` string literals is blanked (length and positions preserved,
+    surrounding quotes kept). Used before pattern checks (e.g. search-tactic or `axiom`
+    detection) so a tactic-like substring inside a string literal does not falsely match.
+    """
+
+    class ParsingState(Enum):
+        Out = 1
+        LineComment = 2
+        BlockComment = 3
+        StringLiteral = 4
+
+    state = ParsingState.Out
+    i = 0
+    depth = 0
+    out = []
+    n = len(src)
+
+    while i < n:
+        c = src[i]
+        c2 = src[i : i + 2]
+
+        if state == ParsingState.Out:
+            if c == '"':
+                state = ParsingState.StringLiteral
+                out.append(c)
+                i += 1
+            elif c2 == "--":
+                state = ParsingState.LineComment
+                out.append(c2)
+                i += 2
+            elif c2 == "/-":
+                state = ParsingState.BlockComment
+                depth = 1
+                out.append(c2)
+                i += 2
+            else:
+                out.append(c)
+                i += 1
+
+        elif state == ParsingState.LineComment:
+            if c == "\n":
+                state = ParsingState.Out
+            out.append(c)
+            i += 1
+
+        elif state == ParsingState.BlockComment:
+            if c2 == "/-":
+                depth += 1
+                out.append(c2)
+                i += 2
+            elif c2 == "-/":
+                depth -= 1
+                out.append(c2)
+                i += 2
+                if depth == 0:
+                    state = ParsingState.Out
+            else:
+                out.append(c)
+                i += 1
+
+        elif state == ParsingState.StringLiteral:
+            if c == '"':
+                state = ParsingState.Out
+                out.append(c)
+            else:
+                out.append(" " if c != "\n" else "\n")
+            i += 1
+
+    return "".join(out)
+
+
 def comment_spans(src: str) -> list[tuple[int, int]]:
     """Character spans (start, end) of every Lean comment region in `src`.
 

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -40,7 +40,10 @@ STRIPPABLE_DECLARATION_TYPES = frozenset(
 # one of these delimiters (matching list_all_declarations_in_lean_code's name pattern).
 # Use this after a name instead of `\b`: `\b` treats `.` as a boundary, so "Treap" would
 # wrongly match the earlier "Treap.insert" declaration.
-DECL_NAME_END = r"(?![^\s:({\[\]},])"
+# A universe binder `.{u}` (valid Lean 4 syntax, e.g. `theorem foo.{u} ...`) may directly
+# follow the name, so allow a literal `.{` as a valid boundary too — but still reject a
+# qualified-name continuation like `foo.bar` (where `foo` is a prefix of another decl).
+DECL_NAME_END = r"(?:(?=\.\{)|(?![^\s:({\[\]},]))"
 
 # Search/suggestion tactics that emit "Try this" and must not appear in a final proof.
 # These names are tactic-only — none are API methods ending in "?", so real code like

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -121,6 +121,15 @@ class LLMClient:
         self._retry_config: dict = config.retry_config
 
     @property
+    def model_id(self) -> str:
+        """Best-effort model identifier for logging (provider attr varies)."""
+        return (
+            getattr(self._base_llm, "model", None)
+            or getattr(self._base_llm, "model_name", None)
+            or "<unknown>"
+        )
+
+    @property
     def profile(self) -> dict:
         """Model metadata (max_input_tokens, max_output_tokens, capabilities, etc.).
 

--- a/tests/unit/prover/test_proof_body_restriction.py
+++ b/tests/unit/prover/test_proof_body_restriction.py
@@ -65,6 +65,46 @@ def test_restriction_fragment_mentions_key_rules():
     assert "locked" in PROOF_BODY_RESTRICTION_PROMPT.lower()
 
 
+class TestSorriesFeedbackCarriesPreambleWarning:
+    def test_warning_appended_to_content_when_provided(self):
+        from ax_prover.models.messages import SorriesGoalStateFeedback
+
+        warning = _dropped_preamble_warning(True, ["Mathlib.Tactic"], [])
+        feedback = SorriesGoalStateFeedback(
+            sorry_count=1,
+            goal_state_at_sorries="⊢ True",
+            dropped_preamble_warning=warning,
+        )
+        assert "SORRIES DETECTED" in feedback.content
+        assert "IMPORTS/OPENS IGNORED" in feedback.content
+        assert "Mathlib.Tactic" in feedback.content
+
+    def test_no_warning_when_empty(self):
+        from ax_prover.models.messages import SorriesGoalStateFeedback
+
+        feedback = SorriesGoalStateFeedback(
+            sorry_count=1,
+            goal_state_at_sorries="⊢ True",
+            dropped_preamble_warning="",
+        )
+        assert "IMPORTS/OPENS IGNORED" not in feedback.content
+
+
+def test_builder_node_surfaces_dropped_preamble_on_sorries_path():
+    """Guard: the build-success-with-sorries branch must surface the dropped-preamble warning.
+
+    Exercising _builder_node fully requires LLM/Lean, so assert via source that the
+    sorries branch wires the warning through to SorriesGoalStateFeedback.
+    """
+    import inspect
+
+    from ax_prover.prover.agent import ProverAgent
+
+    source = inspect.getsource(ProverAgent._builder_node)
+    assert "_dropped_preamble_warning(" in source
+    assert "dropped_preamble_warning=" in source
+
+
 def test_proposer_node_wires_in_the_prompt_builder():
     """Guard against the proposer node bypassing build_proposer_system_prompt.
 

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -591,3 +591,23 @@ class TestBodySearchEndToEnd:
     def test_no_match_message_unchanged(self, where_project):
         searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
         assert searcher.search("zzz_nope") == 'No declarations matching "zzz_nope" found.'
+
+    def test_body_fallback_reads_each_file_once(self, where_project, monkeypatch):
+        # A name-miss that succeeds only via the body fallback must NOT re-walk and
+        # re-read the tree: each .lean file is read exactly once per search.
+        import pathlib
+
+        read_counts: dict[str, int] = {}
+        original = pathlib.Path.read_text
+
+        def counting_read_text(self, *args, **kwargs):
+            if str(self).endswith(".lean"):
+                read_counts[str(self)] = read_counts.get(str(self), 0) + 1
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "read_text", counting_read_text)
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(where_project))
+        out = searcher.search("query_aux")  # name miss -> body fallback hit
+        assert "matched in body" in out
+        assert read_counts  # at least one .lean file was read
+        assert all(count == 1 for count in read_counts.values()), read_counts

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -457,6 +457,41 @@ class TestAmbiguousSimpleName:
         assert "Challenges/Dup.lean:9" in result  # B.insert
 
 
+# A real `def foo` preceded by a commented-out `def foo` (line-start, inside a block
+# comment). The raw-content matcher would otherwise pick the commented one first.
+COMMENTED_DECL_LEAN = """import Mathlib
+
+/-
+def foo := 1
+-/
+def foo := 2
+"""
+
+
+@pytest.fixture
+def commented_decl_project(tmp_path):
+    root = tmp_path / "challenges"
+    (root / "Challenges").mkdir(parents=True)
+    (root / "lakefile.toml").write_text('name = "challenges"\n')
+    (root / "Challenges" / "Commented.lean").write_text(COMMENTED_DECL_LEAN)
+    return root
+
+
+class TestCommentedDeclaration:
+    def test_declaration_line_skips_commented_decl(self):
+        # The real `def foo := 2` is on line 6; the commented one (line 4) must be ignored.
+        assert _declaration_line(COMMENTED_DECL_LEAN, "foo", 0) == 6
+
+    def test_search_returns_real_block_not_commented(self, commented_decl_project):
+        searcher = LocalLeanSearcher(
+            SearchLeanLocalConfig(), base_folder=str(commented_decl_project)
+        )
+        result = searcher.search("foo")
+        assert "def foo := 2" in result
+        assert ":= 1" not in result
+        assert "Challenges/Commented.lean:6" in result
+
+
 class TestIdentifierMatch:
     def test_matches_standalone_identifier(self):
         assert _identifier_match("query_aux", "  x := query_aux n 0")

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -260,6 +260,39 @@ class TestLocalLeanSearcher:
         assert "Found 3 declaration(s)" in result
         assert "Additional matches" in result
 
+    def test_single_oversized_match_is_truncated_not_dropped(self, tmp_path):
+        # A single match whose block exceeds max_chars must still surface some of the
+        # body plus a truncation marker, NOT an empty body with only a "not shown" note.
+        root = tmp_path / "challenges"
+        (root / "Challenges").mkdir(parents=True)
+        (root / "lakefile.toml").write_text('name = "challenges"\n')
+        body_lines = "\n".join(f"  step_{i} := {i}" for i in range(50))
+        (root / "Challenges" / "Big.lean").write_text(f"def bigDecl : Nat :=\n{body_lines}\n  0\n")
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(max_chars=200), base_folder=str(root))
+        result = searcher.search("bigDecl")
+        assert "Found 1 declaration(s)" in result
+        # The whole oversized block must NOT be shown (it was truncated).
+        assert "step_49" not in result
+        # Part of the actual declaration body must appear.
+        assert "def bigDecl" in result
+        # A truncation marker must be present.
+        assert "truncated" in result
+        # It must NOT claim the only match is "not shown".
+        assert "Additional matches (not shown" not in result
+
+    def test_normal_small_result_not_truncated(self, tmp_path):
+        # A normal small result that fits the budget is rendered fully, no marker.
+        root = tmp_path / "challenges"
+        (root / "Challenges").mkdir(parents=True)
+        (root / "lakefile.toml").write_text('name = "challenges"\n')
+        (root / "Challenges" / "Small.lean").write_text("def smallDecl : Nat :=\n  1\n")
+        searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root))
+        result = searcher.search("smallDecl")
+        assert "Found 1 declaration(s)" in result
+        assert "def smallDecl : Nat :=" in result
+        assert "truncated" not in result
+        assert "Additional matches" not in result
+
     def test_search_logs_match_count_at_info(self, treap_project, caplog):
         import logging
 

--- a/tests/unit/utils/test_build.py
+++ b/tests/unit/utils/test_build.py
@@ -150,3 +150,58 @@ def test_temporary_proposal_still_applies_code_when_restricted(tmp_path):
         # Imports/opens are still suppressed.
         assert "import Mathlib.Tactic" not in content
         assert "open Nat" not in content
+
+
+def _make_namespaced_demo_project(tmp_path) -> Location:
+    """Write a Lean file containing a `B.insert` target and return its Location.
+
+    The file does not yet matter for selection (the proposal carries the new code);
+    we just need a valid original file whose target declaration can be replaced.
+    """
+    (tmp_path / "Demo.lean").write_text(
+        "namespace B\n\ndef insert : Nat := sorry\n\nend B\n",
+        encoding="utf-8",
+    )
+    return Location(name="B.insert", module_path="Demo", is_external=False)
+
+
+def test_temporary_proposal_selects_target_by_namespace(tmp_path):
+    """When the proposal code has two same-simple-name decls, the namespace-qualified
+    target (B.insert, the SECOND occurrence) is applied — not the first (A.insert)."""
+    location = _make_namespaced_demo_project(tmp_path)
+    proposal = ProposalMessage(
+        reasoning="r",
+        code=(
+            "namespace A\n\n"
+            "def insert : Nat := 111\n\n"
+            "end A\n\n"
+            "namespace B\n\n"
+            "def insert : Nat := 222\n\n"
+            "end B\n"
+        ),
+        location=location,
+        imports=[],
+        opens=[],
+    )
+    with TemporaryProposal(str(tmp_path), location, proposal) as applier:
+        assert applier.success, applier.error
+        content = (Path(tmp_path) / applier.location.path).read_text(encoding="utf-8")
+        # The TARGET (B.insert, value 222) must be applied, not the first decl (A.insert).
+        assert "222" in content
+        assert "111" not in content
+
+
+def test_temporary_proposal_single_declaration_regression(tmp_path):
+    """The common case (single declaration, simple name, occurrence 0) is unchanged."""
+    location = _make_demo_project(tmp_path)
+    proposal = ProposalMessage(
+        reasoning="r",
+        code="theorem thm : True := by\n  exact trivial",
+        location=location,
+        imports=[],
+        opens=[],
+    )
+    with TemporaryProposal(str(tmp_path), location, proposal) as applier:
+        assert applier.success, applier.error
+        content = (Path(tmp_path) / applier.location.path).read_text(encoding="utf-8")
+        assert "exact trivial" in content

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -523,3 +523,25 @@ class TestFindStrippedDeclarationNames:
         """Helpers defined after the target are also stripped."""
         code = "theorem foo : True := by trivial\n\nlemma bar : True := by trivial\n"
         assert find_stripped_declaration_names(code, "foo") == ["bar"]
+
+    def test_ignores_namespace_section_end_open(self):
+        """Structural commands (namespace/section/end/open) are never 'stripped' decls."""
+        code = "namespace Foo\n  theorem target : True := by sorry\nend Foo"
+        assert find_stripped_declaration_names(code, "target") == []
+
+    def test_ignores_file_level_open(self):
+        """A file-level `open` must not be reported as a stripped declaration."""
+        code = "open Nat\n\ntheorem target (n : Nat) : n = n := by rfl"
+        result = find_stripped_declaration_names(code, "target")
+        assert "Nat" not in result
+        assert result == []
+
+    def test_genuine_helper_still_reported_alongside_structural(self):
+        """A real standalone helper is reported even when wrapped in a namespace."""
+        code = (
+            "namespace Foo\n"
+            "lemma helper (n : Nat) : n = n := by rfl\n"
+            "theorem target (n : Nat) : n = n := by rfl\n"
+            "end Foo"
+        )
+        assert find_stripped_declaration_names(code, "target") == ["helper"]

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -289,6 +289,41 @@ class TestExtractFunctionFromContent:
         code = "theorem foo.bar : True := trivial"
         assert extract_function_from_content(code, "foo") is None
 
+    def test_includes_leading_open_in_prefix(self):
+        """A contiguous `open … in` prefix that binds to the decl is included."""
+        code = "open Nat in\ntheorem target (n : Nat) : n = n := by rfl"
+        block = extract_function_from_content(code, "target")
+        assert block is not None
+        assert "open Nat in" in block
+        assert "theorem target" in block
+
+    def test_includes_multiple_in_prefixes(self):
+        """Several stacked `… in` prefix commands are all included."""
+        code = (
+            "set_option maxHeartbeats 400000 in\nopen Nat in\ntheorem target : True := by trivial"
+        )
+        block = extract_function_from_content(code, "target")
+        assert block is not None
+        assert block.startswith("set_option maxHeartbeats 400000 in")
+        assert "open Nat in" in block
+        assert "theorem target" in block
+
+    def test_does_not_pull_in_preceding_unrelated_decl(self):
+        """An ordinary preceding declaration is not pulled into the block."""
+        code = "theorem other : True := trivial\ntheorem target : True := trivial"
+        block = extract_function_from_content(code, "target")
+        assert block is not None
+        assert "other" not in block
+        assert block.startswith("theorem target")
+
+    def test_stops_at_blank_line_before_in_prefix(self):
+        """A blank line separates an `… in` prefix that does not bind to the decl."""
+        code = "open Nat in\n\ntheorem target : True := by trivial"
+        block = extract_function_from_content(code, "target")
+        assert block is not None
+        assert "open Nat in" not in block
+        assert block.startswith("theorem target")
+
 
 class TestExtractTheoremName:
     """Tests for extract_theorem_name function."""

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -324,6 +324,30 @@ class TestExtractFunctionFromContent:
         assert "open Nat in" not in block
         assert block.startswith("theorem target")
 
+    def test_commented_decl_skipped_block_comment(self):
+        """A `def foo` inside a block comment must not be selected as occurrence 0."""
+        code = "/-\ndef foo := 1\n-/\ndef foo := 2\n"
+        block = extract_function_from_content(code, "foo", 0)
+        assert block is not None
+        assert block.startswith("def foo := 2")
+        assert ":= 1" not in block
+
+    def test_commented_decl_skipped_line_comment(self):
+        """A `def foo` after a `--` line comment must not be selected as occurrence 0."""
+        code = "-- def foo := 1\ndef foo := 2\n"
+        block = extract_function_from_content(code, "foo", 0)
+        assert block is not None
+        assert block.startswith("def foo := 2")
+        assert ":= 1" not in block
+
+    def test_no_commented_decls_occurrence_unchanged(self):
+        """With no commented decls, occurrence indexing is unchanged (regression guard)."""
+        code = "def foo := 1\n\ndef foo := 2\n"
+        first = extract_function_from_content(code, "foo", 0)
+        second = extract_function_from_content(code, "foo", 1)
+        assert first is not None and first.startswith("def foo := 1")
+        assert second is not None and second.startswith("def foo := 2")
+
 
 class TestExtractTheoremName:
     """Tests for extract_theorem_name function."""

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -277,6 +277,18 @@ class TestExtractFunctionFromContent:
         assert insert is not None
         assert insert.startswith("def Treap.insert")
 
+    def test_universe_polymorphic_name(self):
+        """A name followed by a universe binder `.{u}` is extractable."""
+        code = "theorem foo.{u} (x : Type u) : x = x := by rfl"
+        block = extract_function_from_content(code, "foo")
+        assert block is not None
+        assert block.startswith("theorem foo.{u}")
+
+    def test_universe_binder_does_not_match_qualified_name(self):
+        """Searching `foo` must not match a different decl `foo.bar`."""
+        code = "theorem foo.bar : True := trivial"
+        assert extract_function_from_content(code, "foo") is None
+
 
 class TestExtractTheoremName:
     """Tests for extract_theorem_name function."""

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -5,6 +5,7 @@ import pytest
 from ax_prover.models.declaration import Declaration, DeclarationType
 from ax_prover.utils.lean_parsing import (
     SEARCH_TACTIC_PATTERN,
+    blank_string_literals,
     count_pattern,
     extract_function_from_content,
     extract_theorem_name,
@@ -616,3 +617,54 @@ class TestFindStrippedDeclarationNames:
             "end Foo"
         )
         assert find_stripped_declaration_names(code, "target") == ["helper"]
+
+
+class TestBlankStringLiterals:
+    """Tests for blank_string_literals function."""
+
+    def test_blanks_inner_content_preserves_quotes_and_length(self):
+        src = 'let x := "simp? in here"'
+        result = blank_string_literals(src)
+        assert len(result) == len(src)
+        assert result == 'let x := "' + " " * len("simp? in here") + '"'
+        # Quotes preserved, inner content blanked.
+        assert result[9] == '"'
+        assert result[-1] == '"'
+
+    def test_code_outside_strings_untouched(self):
+        src = "theorem foo : True := by simp"
+        assert blank_string_literals(src) == src
+
+    def test_search_tactic_inside_string_not_matched(self):
+        """count_pattern over blanked source no longer flags a tactic in a string."""
+        src = 'theorem foo : True := by trivial -- note: "use simp? here"'
+        stripped = strip_comments(src)
+        # Without blanking, the comment is gone but if it were a string it would match.
+        blanked = blank_string_literals(stripped)
+        count, _ = count_pattern(blanked, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 0
+
+    def test_search_tactic_in_string_literal_not_matched(self):
+        src = 'theorem foo : True := by exact (id "use simp? to solve" |> fun _ => trivial)'
+        blanked = blank_string_literals(strip_comments(src))
+        count, _ = count_pattern(blanked, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 0
+
+    def test_real_search_tactic_still_matched(self):
+        src = "theorem foo : True := by simp?"
+        blanked = blank_string_literals(strip_comments(src))
+        count, _ = count_pattern(blanked, pattern=SEARCH_TACTIC_PATTERN)
+        assert count == 1
+
+    def test_axiom_word_in_string_not_matched(self):
+        src = 'theorem foo : True := by exact (id "this is an axiom" |> fun _ => trivial)'
+        blanked = blank_string_literals(strip_comments(src))
+        count, _ = count_pattern(blanked, pattern=r"\baxiom\b")
+        assert count == 0
+
+    def test_empty_string(self):
+        assert blank_string_literals("") == ""
+
+    def test_no_strings_identity(self):
+        src = "def add (a b : Nat) : Nat := a + b"
+        assert blank_string_literals(src) == src


### PR DESCRIPTION
Fixes the 10 findings from the high-effort code review of the experiment branch (each TDD'd, committed separately).

**Correctness**
1. `find_stripped_declaration_names` no longer flags `namespace`/`section`/`end`/`open` as "stripped standalone declarations" (allowlist of real declaration types) — stops false "inline every helper" advice.
2. `DECL_NAME_END` now allows universe-polymorphic targets `theorem foo.{u}` (was returning None → "Failed to apply code").
3. Search-tactic/axiom detection no longer false-positives on `simp?`/`axiom` substrings inside string literals (`blank_string_literals` before the checks; sorry/admit detection unchanged).
4. `_format_results` always shows at least the first match, truncating with a marker, instead of returning zero bodies when the only match exceeds `max_chars`.
5. Comment-stripping vs raw-content occurrence misalignment fixed (`comment_spans`/`non_comment_matches`): a declaration keyword inside a comment no longer shifts occurrence indices; returned block stays raw.
6. `extract_function_from_content` now keeps a leading `open … in` (and other `… in`) command prefix bound to the declaration instead of dropping it.
7. `TemporaryProposal` resolves the target's namespace-qualified occurrence (`resolve_target_occurrence`) instead of always extracting occurrence 0; conservative fallback for the common single-decl case.

**Robustness / feature completeness**
8. `max_input_tokens` fallback now logs a warning + uses a named `DEFAULT_MAX_INPUT_TOKENS` constant instead of a silent `or 200_000`.
9. Local/CSLib search reads each `.lean` file once per query (single walk shared with the body fallback) instead of twice on a name-miss.
10. The dropped-imports/opens warning now also surfaces on the build-success-with-sorries path (`SorriesGoalStateFeedback`), not only on build failure — so the proposer learns even when the proposal happens to compile.

**Verification:** 395 unit tests pass; ruff clean; no circular imports. Two of the original candidates were refuted in review and intentionally not changed (body-match `.`-exclusion is documented-intentional; the version regex is correct for all current Claude IDs).

Known non-blocking edge (finding #6): a `--` comment line ending in the word "in" directly above the target can be pulled into the extracted block — benign (compiles; never swallows a real declaration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core proposal application and builder validation paths used on every prove iteration; risk is mitigated by broad unit tests and conservative fallbacks when target resolution is ambiguous.
> 
> **Overview**
> Addresses ten code-review findings on the experiment branch: **Lean parsing and proposal application** are tightened so the prover and local search behave correctly on real Mathlib-style code.
> 
> **Proposal application** now resolves the namespace-qualified target (`resolve_target_occurrence`) instead of always taking the first occurrence of a simple name, and declaration extraction keeps bound `… in` prefixes (e.g. `open Nat in`). Universe-polymorphic names (`theorem foo.{u}`) match via an updated `DECL_NAME_END`. Commented-out declaration keywords no longer shift occurrence indices (`non_comment_matches` / `comment_spans`).
> 
> **Builder feedback** limits “stripped helper” warnings to real declaration types (`STRIPPABLE_DECLARATION_TYPES`), blanks string literals before `axiom` / search-tactic checks to avoid false positives, and prepends the dropped-imports/opens warning to **sorry** feedback when the build succeeds under a locked file. Missing `max_input_tokens` in the LangChain profile now logs a warning and uses `DEFAULT_MAX_INPUT_TOKENS` instead of a silent fallback.
> 
> **Local Lean search** reads each `.lean` file once per query (body fallback reuses cache), skips matches inside comments for line numbers, and truncates a single oversized hit instead of showing nothing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5c558e693c5fd0306fa79569dfa326e0bd6d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->