### PR TITLE
feat: cache used local-search definitions across iterations (WS1)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-ws1-local-search-used-definition-caching.md
+++ b/docs/superpowers/plans/2026-06-08-ws1-local-search-used-definition-caching.md
@@ -1,0 +1,724 @@
+# WS1 — Local-search used-definition caching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the prover re-querying the same local definitions every iteration by caching, verbatim and append-only, the local-search results the proof actually used, and injecting them into each subsequent proposer prompt.
+
+**Architecture:** The persistent `LocalLeanSearcher` records every declaration it returns this run. After each attempt, the memory node deterministically intersects that pool with the identifiers used in the proposed code (excluding the target), appends the verbatim definitions to a run-scoped `used_definitions` cache on the graph state, and the proposer renders them in a `<local-definitions>` block. The cache bypasses the experience-summarizer LLM so Lean source stays byte-exact.
+
+**Tech Stack:** Python 3.12, LangChain/LangGraph, Pydantic, pytest. Branch off `local-lean-search-tool`; PR back into `local-lean-search-tool`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md`
+
+---
+
+## File structure
+
+- `src/ax_prover/tools/local_lean_search.py` — `_search_root` returns `(text, decls)`; `LocalLeanSearcher.returned_declarations` + `_record_returned`; pure helpers `identifier_in_code`, `format_cached_definition_entry`, `accumulate_used_definitions`; caps `MAX_CACHED_DEFINITIONS`, `MAX_CACHED_DEFINITION_CHARS`.
+- `src/ax_prover/tools/cslib_search.py` — unpack `(text, _)` from `_search_root` (CSLib results are never cached).
+- `src/ax_prover/models/proving.py` — new `used_definitions: dict[str, str]` state field.
+- `src/ax_prover/prover/prompts.py` — `LOCAL_DEFINITIONS_USER_PROMPT` template + one nudge line in the iterative proposer system prompt.
+- `src/ax_prover/prover/agent.py` — capture `self._local_searcher`; `_find_local_searcher`; `_accumulate_used_definitions`; merge in `_memory_processor_node`; inject the block in `_proposer_node`.
+- Tests: `tests/unit/tools/test_local_lean_search.py` (extend), `tests/unit/prover/test_used_definition_caching.py` (new).
+
+Before starting: create the branch.
+
+```bash
+git checkout local-lean-search-tool && git pull --ff-only
+git checkout -b ws1-local-search-used-definition-caching
+```
+
+---
+
+## Task 1: `_search_root` returns structured declarations alongside text
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (function `_search_root`, ~lines 309-327)
+- Modify: `src/ax_prover/tools/cslib_search.py` (method `CslibSearcher.search`, ~line 72)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+from pathlib import Path
+
+from ax_prover.tools.local_lean_search import SearchLeanLocalConfig, _search_root
+
+
+def _write(tmp_path: Path, name: str, text: str) -> None:
+    (tmp_path / name).write_text(text, encoding="utf-8")
+
+
+def test_search_root_returns_text_and_decls_on_name_match(tmp_path):
+    _write(tmp_path, "Def.lean", "def extract_min : Nat := 0\n")
+    text, decls = _search_root(tmp_path, "extract_min", SearchLeanLocalConfig())
+    assert "extract_min" in text
+    assert len(decls) == 1
+    qualified_name, block, locations = decls[0]
+    assert qualified_name == "extract_min"
+    assert "def extract_min" in block
+    assert locations and locations[0][1] == 1  # (path, line)
+
+
+def test_search_root_returns_empty_decls_on_no_match(tmp_path):
+    _write(tmp_path, "Def.lean", "def foo : Nat := 0\n")
+    text, decls = _search_root(tmp_path, "nonexistent_name", SearchLeanLocalConfig())
+    assert "No declarations matching" in text
+    assert decls == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py::test_search_root_returns_text_and_decls_on_name_match -v`
+Expected: FAIL — `ValueError: too many values to unpack` (currently returns a bare `str`).
+
+- [ ] **Step 3: Change `_search_root` to return a tuple**
+
+Replace the body of `_search_root` (keep the docstring) so every return path yields `(text, decls)`:
+
+```python
+def _search_root(
+    root: Path, query: str, config: SearchLeanLocalConfig, *, label: str = "LocalLeanSearch"
+) -> tuple[str, list[tuple[str, str, list[tuple[Path, int]]]]]:
+    """Search `root` by declaration name; fall back to body search only if name finds nothing.
+
+    Returns the formatted text plus the structured declarations it formatted (empty on no match).
+    Walks the tree and reads each file once; the body fallback reuses the cached contents.
+    """
+    files = _read_lean_files(root)
+    decls = _collect_matches(files, query, body=False)
+    if decls:
+        logger.info(f"{label}: Found {len(decls)} declarations for '{query}' under {root}")
+        return _format_results(query, decls, config), decls
+    body_decls = _collect_matches(files, query, body=True)
+    if body_decls:
+        logger.info(f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}")
+        return _format_results(query, body_decls, config, body_match=True), body_decls
+    logger.info(f"{label}: No results for '{query}'")
+    return f'No declarations matching "{query}" found.', []
+```
+
+- [ ] **Step 4: Update both callers to unpack the tuple**
+
+In `src/ax_prover/tools/local_lean_search.py`, `LocalLeanSearcher.search` currently ends with `return _search_root(root, query, self.config)`. Change that line to:
+
+```python
+        text, _decls = _search_root(root, query, self.config)
+        return text
+```
+
+(Task 3 replaces `_decls` with real recording; this keeps the build green meanwhile.)
+
+In `src/ax_prover/tools/cslib_search.py`, `CslibSearcher.search` currently ends with `return _search_root(cslib, query, self.config, label="CslibSearch")`. Change that line to:
+
+```python
+        text, _decls = _search_root(cslib, query, self.config, label="CslibSearch")
+        return text
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py tests/unit/tools/test_cslib_search.py -q`
+Expected: PASS (new tests pass; all existing local/cslib search tests still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py src/ax_prover/tools/cslib_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "refactor: _search_root returns (text, decls); callers unpack"
+```
+
+---
+
+## Task 2: Pure caching helpers (`identifier_in_code`, `format_cached_definition_entry`, `accumulate_used_definitions`)
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (add caps + 3 functions, near the other module-level helpers, e.g. after `_identifier_match`)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+from ax_prover.tools.local_lean_search import (
+    MAX_CACHED_DEFINITIONS,
+    accumulate_used_definitions,
+    format_cached_definition_entry,
+    identifier_in_code,
+)
+
+
+def test_identifier_in_code_matches_qualified_and_simple():
+    assert identifier_in_code("BinaryHeap.extract_min", "  exact extract_min h")
+    assert identifier_in_code("BinaryHeap.extract_min", "  exact BinaryHeap.extract_min h")
+    assert not identifier_in_code("extract_min", "  exact extract_minimum h")  # not whole-identifier
+    assert not identifier_in_code("heapify", "  simp")
+
+
+def test_format_cached_definition_entry_has_location_header_and_block():
+    entry = format_cached_definition_entry("A.foo", "def foo := 1", Path("Def.lean"), 3)
+    assert entry == "-- A.foo — Def.lean:3\ndef foo := 1"
+
+
+def _pool():
+    return {
+        "BinaryHeap.extract_min": ("def extract_min : Nat := 0", Path("Def.lean"), 5),
+        "BinaryHeap.heapify": ("def heapify : Nat := 1", Path("Def.lean"), 9),
+    }
+
+
+def test_accumulate_adds_only_used_definitions():
+    code = "theorem t : True := by have := extract_min; trivial"
+    result = accumulate_used_definitions({}, _pool(), code, target_name="t")
+    assert "BinaryHeap.extract_min" in result
+    assert "BinaryHeap.heapify" not in result  # returned but not used in code
+
+
+def test_accumulate_excludes_target_by_simple_name():
+    pool = {"Foo.extract_min": ("def extract_min := 0", Path("Def.lean"), 1)}
+    code = "theorem extract_min : True := by exact extract_min"
+    result = accumulate_used_definitions({}, pool, code, target_name="extract_min")
+    assert result == {}  # the only candidate shares the target's simple name
+
+
+def test_accumulate_is_monotonic_and_dedups():
+    prior = {"BinaryHeap.heapify": "-- cached earlier"}
+    code = "theorem t : True := by exact extract_min"  # heapify NOT used now
+    result = accumulate_used_definitions(prior, _pool(), code, target_name="t")
+    assert result["BinaryHeap.heapify"] == "-- cached earlier"  # preserved, not wiped
+    assert "BinaryHeap.extract_min" in result  # newly used, added
+    # Re-running with the same pool does not duplicate or change existing entries.
+    again = accumulate_used_definitions(result, _pool(), code, target_name="t")
+    assert again == result
+
+
+def test_accumulate_respects_count_cap():
+    pool = {
+        f"N.def_{i}": (f"def def_{i} := {i}", Path("Def.lean"), i + 1)
+        for i in range(MAX_CACHED_DEFINITIONS + 5)
+    }
+    code = " ".join(f"def_{i}" for i in range(MAX_CACHED_DEFINITIONS + 5))
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert len(result) == MAX_CACHED_DEFINITIONS
+
+
+def test_accumulate_respects_char_cap():
+    big_block = "x" * 9000  # two of these exceed the 12000-char cap
+    pool = {
+        "N.a": (big_block, Path("Def.lean"), 1),
+        "N.b": (big_block, Path("Def.lean"), 2),
+    }
+    code = "a b"  # both 'a' and 'b' referenced as whole identifiers
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert len(result) == 1  # second entry would blow the char budget
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "identifier_in_code or format_cached or accumulate" -v`
+Expected: FAIL — `ImportError: cannot import name 'accumulate_used_definitions'`.
+
+- [ ] **Step 3: Implement the caps and helpers**
+
+In `src/ax_prover/tools/local_lean_search.py`, add the caps near the other module constants (after `EXCLUDED_DIR`):
+
+```python
+# Caps for the run-scoped cache of used local definitions (consumed by the memory node).
+MAX_CACHED_DEFINITIONS = 24
+MAX_CACHED_DEFINITION_CHARS = 12000
+```
+
+Add these functions after `_identifier_match` (which they reuse):
+
+```python
+def identifier_in_code(name: str, code: str) -> bool:
+    """True if `name` or its final dotted segment appears in `code` as a whole identifier."""
+    candidates = {name, name.rsplit(".", 1)[-1]}
+    return any(_identifier_match(candidate, code) for candidate in candidates)
+
+
+def format_cached_definition_entry(qualified_name: str, block: str, path: Path, line: int) -> str:
+    """Render one cached definition as a located, verbatim source entry."""
+    return f"-- {qualified_name} — {path}:{line}\n{block}"
+
+
+def accumulate_used_definitions(
+    cached: dict[str, str],
+    returned_declarations: dict[str, tuple[str, "Path", int]],
+    code: str,
+    target_name: str | None,
+) -> dict[str, str]:
+    """Append local-search results that `code` actually used to the run-scoped `cached` map.
+
+    Append-only and deduped by qualified name. An entry is added only when the local-search tool
+    returned it (it is in `returned_declarations`) AND it is referenced in `code` as a whole
+    identifier. The target theorem's own simple name is excluded. Respects MAX_CACHED_DEFINITIONS
+    and MAX_CACHED_DEFINITION_CHARS; existing entries are never removed.
+    """
+    merged = dict(cached)
+    total_chars = sum(len(entry) for entry in merged.values())
+    target_simple = target_name.rsplit(".", 1)[-1] if target_name else None
+    for qualified_name, (block, path, line) in returned_declarations.items():
+        if qualified_name in merged:
+            continue
+        if len(merged) >= MAX_CACHED_DEFINITIONS:
+            break
+        if target_simple and qualified_name.rsplit(".", 1)[-1] == target_simple:
+            continue
+        if not identifier_in_code(qualified_name, code):
+            continue
+        entry = format_cached_definition_entry(qualified_name, block, path, line)
+        if total_chars + len(entry) > MAX_CACHED_DEFINITION_CHARS:
+            break
+        merged[qualified_name] = entry
+        total_chars += len(entry)
+    return merged
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "identifier_in_code or format_cached or accumulate" -v`
+Expected: PASS (all 7 new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat: pure helpers for run-scoped used-definition cache"
+```
+
+---
+
+## Task 3: `LocalLeanSearcher` records returned declarations
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (`LocalLeanSearcher.__init__` ~line 336, `.search` ~line 363; add `_record_returned`)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+from ax_prover.tools.local_lean_search import LocalLeanSearcher
+
+
+def _make_lake_project(tmp_path) -> str:
+    (tmp_path / "lakefile.toml").write_text("name = \"demo\"\n", encoding="utf-8")
+    (tmp_path / "Def.lean").write_text(
+        "def extract_min : Nat := 0\ndef heapify : Nat := 1\n", encoding="utf-8"
+    )
+    return str(tmp_path)
+
+
+def test_searcher_accumulates_returned_declarations_across_calls(tmp_path):
+    base = _make_lake_project(tmp_path)
+    searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=base)
+
+    searcher.search("extract_min")
+    assert "extract_min" in searcher.returned_declarations
+    block, path, line = searcher.returned_declarations["extract_min"]
+    assert "def extract_min" in block
+
+    searcher.search("heapify")
+    # First result is retained; second is added (accumulation, not replacement).
+    assert set(searcher.returned_declarations) == {"extract_min", "heapify"}
+
+
+def test_searcher_records_nothing_on_miss(tmp_path):
+    base = _make_lake_project(tmp_path)
+    searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=base)
+    searcher.search("totally_absent_name")
+    assert searcher.returned_declarations == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "searcher_accumulates or searcher_records_nothing" -v`
+Expected: FAIL — `AttributeError: 'LocalLeanSearcher' object has no attribute 'returned_declarations'`.
+
+- [ ] **Step 3: Implement recording**
+
+In `LocalLeanSearcher.__init__`, add the field after `self._resolution = None`:
+
+```python
+        self.returned_declarations: dict[str, tuple[str, Path, int]] = {}
+```
+
+Replace the final two lines of `LocalLeanSearcher.search` (`text, _decls = _search_root(...)` / `return text` from Task 1) with:
+
+```python
+        text, decls = _search_root(root, query, self.config)
+        self._record_returned(decls)
+        return text
+```
+
+Add the method to `LocalLeanSearcher`:
+
+```python
+    def _record_returned(
+        self, decls: list[tuple[str, str, list[tuple[Path, int]]]]
+    ) -> None:
+        """Accumulate returned declarations for the run, keyed by qualified name (first-seen wins)."""
+        for qualified_name, block, locations in decls:
+            if qualified_name in self.returned_declarations or not locations:
+                continue
+            path, line = locations[0]
+            self.returned_declarations[qualified_name] = (block, path, line)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -q`
+Expected: PASS (full file green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat: LocalLeanSearcher records returned declarations for the run"
+```
+
+---
+
+## Task 4: `used_definitions` state field
+
+**Files:**
+- Modify: `src/ax_prover/models/proving.py` (after the `experience` field, ~line 73)
+- Test: `tests/unit/prover/test_used_definition_caching.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/prover/test_used_definition_caching.py`:
+
+```python
+"""Tests for the WS1 used-definition caching feature."""
+
+from ax_prover.models.proving import ProverAgentState
+from ax_prover.models.proving import TargetItem
+
+
+def _state() -> ProverAgentState:
+    return ProverAgentState(item=TargetItem(title="t"))
+
+
+def test_used_definitions_defaults_to_empty_dict():
+    state = _state()
+    assert state.used_definitions == {}
+
+
+def test_used_definitions_accepts_mapping():
+    state = ProverAgentState(
+        item=TargetItem(title="t"),
+        used_definitions={"A.foo": "-- A.foo — Def.lean:1\ndef foo := 1"},
+    )
+    assert "A.foo" in state.used_definitions
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/prover/test_used_definition_caching.py -v`
+Expected: FAIL — `ValidationError` / `AttributeError` (`used_definitions` not a field).
+
+- [ ] **Step 3: Add the field**
+
+In `src/ax_prover/models/proving.py`, insert after the `experience` field (before `summary`):
+
+```python
+    used_definitions: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Run-scoped cache of local-search definitions the proof actually used, keyed by "
+            "qualified name → rendered verbatim entry. Append-only across iterations."
+        ),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/prover/test_used_definition_caching.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/models/proving.py tests/unit/prover/test_used_definition_caching.py
+git commit -m "feat: add used_definitions field to ProverAgentState"
+```
+
+---
+
+## Task 5: Proposer prompt template + nudge
+
+**Files:**
+- Modify: `src/ax_prover/prover/prompts.py` (add `LOCAL_DEFINITIONS_USER_PROMPT`; add one nudge line in `PROPOSER_SYSTEM_PROMPT`)
+- Test: `tests/unit/prover/test_used_definition_caching.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/prover/test_used_definition_caching.py`:
+
+```python
+def test_local_definitions_prompt_wraps_definitions():
+    from ax_prover.prover.prompts import LOCAL_DEFINITIONS_USER_PROMPT
+
+    rendered = LOCAL_DEFINITIONS_USER_PROMPT.format(definitions="-- A.foo\ndef foo := 1")
+    assert "<local-definitions>" in rendered
+    assert "</local-definitions>" in rendered
+    assert "def foo := 1" in rendered
+
+
+def test_iterative_system_prompt_mentions_local_definitions():
+    from ax_prover.prover.prompts import PROPOSER_SYSTEM_PROMPT
+
+    assert "<local-definitions>" in PROPOSER_SYSTEM_PROMPT
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/prover/test_used_definition_caching.py -k "local_definitions_prompt or system_prompt_mentions" -v`
+Expected: FAIL — `ImportError` for `LOCAL_DEFINITIONS_USER_PROMPT`.
+
+- [ ] **Step 3: Add the template and the nudge**
+
+In `src/ax_prover/prover/prompts.py`, add after `PROPOSER_USER_PROMPT` (the block ending at the closing `"""` near line 220):
+
+```python
+LOCAL_DEFINITIONS_USER_PROMPT = """
+These project definitions were referenced in your previous attempts and are provided verbatim, so you do NOT need to search for them again:
+
+<local-definitions>
+{definitions}
+</local-definitions>
+"""
+```
+
+In `PROPOSER_SYSTEM_PROMPT` only (the iterative prompt), inside the `<requirements>` "Quality Standards" list, add a bullet immediately after the existing "When searching for lemmas, match the search tool to the file's imports…" line:
+
+```
+    - Project definitions you have already used in previous attempts are provided verbatim in the <local-definitions> section of the message — reference them directly and do NOT search for them again.
+```
+
+(Do not add this to `PROPOSER_SYSTEM_PROMPT_SINGLE_SHOT`: single-shot runs never populate `used_definitions`, so the section never appears there.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/prover/test_used_definition_caching.py -k "local_definitions_prompt or system_prompt_mentions" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/prover/prompts.py tests/unit/prover/test_used_definition_caching.py
+git commit -m "feat: local-definitions prompt template and proposer nudge"
+```
+
+---
+
+## Task 6: Wire the searcher, accumulation, and injection into the agent
+
+**Files:**
+- Modify: `src/ax_prover/prover/agent.py` (imports; `__init__` ~line 94; `create` ~line 135; new `_find_local_searcher` and `_accumulate_used_definitions`; `_memory_processor_node` ~line 238; `_proposer_node` experience block ~line 280)
+- Test: `tests/unit/prover/test_used_definition_caching.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/prover/test_used_definition_caching.py`:
+
+```python
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_find_local_searcher_locates_the_searcher(tmp_path):
+    from ax_prover.prover.agent import ProverAgent
+    from ax_prover.tools.local_lean_search import (
+        LocalLeanSearcher,
+        SearchLeanLocalConfig,
+        create_search_lean_local_tool,
+    )
+
+    (tmp_path / "lakefile.toml").write_text("name = \"demo\"\n", encoding="utf-8")
+    tool = create_search_lean_local_tool(SearchLeanLocalConfig(), base_folder=str(tmp_path))
+    fake = SimpleNamespace(proposer_tools=[tool])
+
+    searcher = ProverAgent._find_local_searcher(fake)
+    assert isinstance(searcher, LocalLeanSearcher)
+
+
+def test_find_local_searcher_returns_none_when_absent():
+    from ax_prover.prover.agent import ProverAgent
+
+    fake = SimpleNamespace(proposer_tools=[])
+    assert ProverAgent._find_local_searcher(fake) is None
+
+
+def test_memory_node_wires_in_accumulation():
+    from ax_prover.prover.agent import ProverAgent
+
+    source = inspect.getsource(ProverAgent._memory_processor_node)
+    assert "_accumulate_used_definitions(" in source
+    assert "used_definitions" in source
+
+
+def test_proposer_node_injects_local_definitions():
+    from ax_prover.prover.agent import ProverAgent
+
+    source = inspect.getsource(ProverAgent._proposer_node)
+    assert "state.used_definitions" in source
+    assert "LOCAL_DEFINITIONS_USER_PROMPT" in source
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/prover/test_used_definition_caching.py -k "find_local_searcher or memory_node_wires or injects_local" -v`
+Expected: FAIL — `AttributeError: type object 'ProverAgent' has no attribute '_find_local_searcher'` (and source assertions fail).
+
+- [ ] **Step 3: Add imports**
+
+In `src/ax_prover/prover/agent.py`, near the existing `from ..tools import create_tool` import, add:
+
+```python
+from ..tools.local_lean_search import (
+    LOCAL_LEAN_SEARCH_TOOL_TYPE,
+    LocalLeanSearcher,
+    accumulate_used_definitions,
+)
+from ..tools.registry import tool_name_from_type
+```
+
+In the prompts import block (where `PROPOSER_SYSTEM_PROMPT`, `PROPOSER_USER_PROMPT`, etc. are imported from `.prompts`), add `LOCAL_DEFINITIONS_USER_PROMPT` to that import list.
+
+- [ ] **Step 4: Initialise `_local_searcher` and capture it after tool creation**
+
+In `__init__`, immediately after `self.proposer_tools = []` (~line 94) add:
+
+```python
+        self._local_searcher: LocalLeanSearcher | None = None
+```
+
+In the `create` classmethod, after `instance.proposer_tools = await instance._create_tools()` and before `instance.app = instance._build_graph()`:
+
+```python
+        instance._local_searcher = instance._find_local_searcher()
+```
+
+- [ ] **Step 5: Add `_find_local_searcher` and `_accumulate_used_definitions` methods**
+
+Add these two methods to `ProverAgent` (e.g. just above `_memory_processor_node`):
+
+```python
+    def _find_local_searcher(self) -> LocalLeanSearcher | None:
+        """Locate the live LocalLeanSearcher behind the local-search tool, if configured."""
+        local_tool_name = tool_name_from_type(LOCAL_LEAN_SEARCH_TOOL_TYPE)
+        for tool in self.proposer_tools:
+            if tool.name == local_tool_name:
+                bound = getattr(getattr(tool, "func", None), "__self__", None)
+                if isinstance(bound, LocalLeanSearcher):
+                    return bound
+        return None
+
+    def _accumulate_used_definitions(self, state: ProverAgentState) -> dict[str, str]:
+        """Append local-search results referenced by the latest proposal to the run cache."""
+        if self._local_searcher is None or not state.last_proposal:
+            return dict(state.used_definitions)
+        target_name = state.item.location.name if state.item.location else None
+        return accumulate_used_definitions(
+            state.used_definitions,
+            self._local_searcher.returned_declarations,
+            state.last_proposal.code,
+            target_name,
+        )
+```
+
+- [ ] **Step 6: Merge accumulation into the memory node**
+
+Replace `_memory_processor_node`:
+
+```python
+    async def _memory_processor_node(self, state: ProverAgentState) -> dict:
+        """Process memory using the configured strategy, plus accumulate used local definitions."""
+        result = await self.memory.process(state)
+        result["used_definitions"] = self._accumulate_used_definitions(state)
+        return result
+```
+
+- [ ] **Step 7: Inject the block in the proposer node**
+
+In `_proposer_node`, right after the existing experience block:
+
+```python
+        if state.experience:
+            query = "\n\n".join([query, state.experience])
+```
+
+add:
+
+```python
+        if state.used_definitions:
+            definitions_block = LOCAL_DEFINITIONS_USER_PROMPT.format(
+                definitions="\n\n".join(state.used_definitions.values())
+            )
+            query = "\n\n".join([query, definitions_block])
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/prover/test_used_definition_caching.py -v`
+Expected: PASS (all WS1 prover tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ax_prover/prover/agent.py tests/unit/prover/test_used_definition_caching.py
+git commit -m "feat: wire used-definition cache through memory and proposer nodes"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Run the whole unit suite**
+
+Run: `.venv/bin/pytest tests/unit -q`
+Expected: PASS (no regressions; previously ~395 tests + the new ones).
+
+- [ ] **Step 2: Lint and format**
+
+Run: `.venv/bin/ruff format . && .venv/bin/ruff check --fix .`
+Expected: "All checks passed!" and files formatted. Commit any formatting changes:
+
+```bash
+git add -A && git commit -m "style: ruff format/lint" || echo "nothing to format"
+```
+
+- [ ] **Step 3: Push and open the PR into `local-lean-search-tool`**
+
+```bash
+git push -u origin ws1-local-search-used-definition-caching
+gh pr create --base local-lean-search-tool --title "feat: cache used local-search definitions across iterations (WS1)" --body "$(cat <<'EOF'
+Caches, verbatim and append-only, the local-search results the proof actually used, and injects them into each subsequent proposer prompt so the agent stops re-querying the same definitions every iteration.
+
+- LocalLeanSearcher records returned declarations for the run
+- Memory node intersects that pool with identifiers used in the proposed code (excludes the target), accumulating into a new `used_definitions` state field
+- Proposer renders a `<local-definitions>` block; verbatim source bypasses the experience-summarizer LLM
+- CSLib/Mathlib results are never cached
+
+Spec: docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** WS1 components 1-6 map to Tasks 3, 6, 4, 6, 5, 2 respectively; caps in Task 2; accumulation guarantee tested in `test_accumulate_is_monotonic_and_dedups`. CSLib exclusion covered by Task 1 Step 4 (CslibSearcher discards decls) and verified by existing cslib tests.
+- **Type consistency:** `returned_declarations: dict[str, tuple[str, Path, int]]` (qualified → block, path, line) is produced by `_record_returned` (Task 3) and consumed by `accumulate_used_definitions` (Task 2) with the identical shape. `_search_root` decls shape `(qualified_name, block, locations)` matches `_collect_matches`'s existing output.
+- **No build break between tasks:** Task 1 Step 4 unpacks into `_decls` so callers compile before Task 3 introduces real recording.

--- a/docs/superpowers/plans/2026-06-08-ws2-local-search-fuzzy-fallback.md
+++ b/docs/superpowers/plans/2026-06-08-ws2-local-search-fuzzy-fallback.md
@@ -1,0 +1,454 @@
+# WS2 — Local-search fuzzy fallback matching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When exact name matching finds nothing, fall back to a fuzzy name match (closest declarations) so the agent recovers from wrong-name guesses — without polluting good exact searches or bloating context.
+
+**Architecture:** Add a middle tier to `_search_root`: exact name match → (new) fuzzy name match → body-identifier match. Fuzzy matching normalizes names and the query into lowercased tokens (split on `.`/`_`/camelCase), scores with `difflib` plus best-token overlap, keeps the top-N above a threshold, and renders under a clear "No exact match — closest declarations" header capped by the existing result/char budget.
+
+**Tech Stack:** Python 3.12 (`difflib`), pytest. Branch off `local-lean-search-tool` **after WS1 is merged** (both touch `_search_root`).
+
+**Spec:** `docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md`
+
+---
+
+## File structure
+
+- `src/ax_prover/tools/local_lean_search.py` — `FUZZY_THRESHOLD`; `_normalize_tokens`, `_fuzzy_score`, `_fuzzy_matching_declarations`, `_collect_fuzzy_matches`; new fuzzy tier in `_search_root`; `fuzzy` flag in `_format_results`; tool + `query` description updates.
+- Test: `tests/unit/tools/test_local_lean_search.py` (extend).
+
+Before starting (WS1 must be merged into `local-lean-search-tool` first):
+
+```bash
+git checkout local-lean-search-tool && git pull --ff-only
+git checkout -b ws2-local-search-fuzzy-fallback
+```
+
+---
+
+## Task 1: Scoring primitives (`_normalize_tokens`, `_fuzzy_score`)
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (add `from difflib import SequenceMatcher`; constant + 2 functions near `_identifier_match`)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+from ax_prover.tools.local_lean_search import _fuzzy_score, _normalize_tokens
+
+
+def test_normalize_tokens_splits_camel_snake_and_qualifier():
+    assert _normalize_tokens("BinaryHeap.decreaseKey") == ["decrease", "key"]
+    assert _normalize_tokens("extract_min") == ["extract", "min"]
+
+
+def test_fuzzy_score_high_for_near_miss():
+    # Underscore/spelling differences still score high.
+    assert _fuzzy_score("extractmin", "BinaryHeap.extract_min") >= 0.8
+    assert _fuzzy_score("decrese_min", "decrease_min") >= 0.7  # typo
+
+
+def test_fuzzy_score_rewards_single_token_match():
+    # Query matches one token of a compound name.
+    assert _fuzzy_score("priority", "decreasePriority") >= 0.6
+
+
+def test_fuzzy_score_low_for_unrelated():
+    assert _fuzzy_score("heapify", "WeightedGraph") < 0.4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "normalize_tokens or fuzzy_score" -v`
+Expected: FAIL — `ImportError: cannot import name '_fuzzy_score'`.
+
+- [ ] **Step 3: Implement the scoring primitives**
+
+At the top of `src/ax_prover/tools/local_lean_search.py`, add to the imports:
+
+```python
+from difflib import SequenceMatcher
+```
+
+Add near `_identifier_match`:
+
+```python
+# Minimum similarity for a fuzzy name suggestion when exact matching finds nothing.
+FUZZY_THRESHOLD = 0.6
+
+
+def _normalize_tokens(name: str) -> list[str]:
+    """Lowercased identifier tokens: drop the namespace qualifier, split on '_' and camelCase."""
+    simple = name.rsplit(".", 1)[-1]
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", simple)
+    return [part.lower() for part in re.split(r"[._\s]+", spaced) if part]
+
+
+def _fuzzy_score(query: str, name: str) -> float:
+    """Similarity in [0, 1] between `query` and a declaration's (final) name.
+
+    Combines a whole-string ratio (ignoring underscores) with the best per-query-token ratio, so a
+    query matching a single token of a compound name (e.g. 'priority' vs 'decreasePriority') still
+    scores well.
+    """
+    simple = name.rsplit(".", 1)[-1].lower()
+    query_squashed = query.lower().replace("_", "").replace(" ", "")
+    whole = SequenceMatcher(None, query_squashed, simple.replace("_", "")).ratio()
+
+    name_tokens = _normalize_tokens(name)
+    query_tokens = _normalize_tokens(query) or [query_squashed]
+    token_score = 0.0
+    for query_token in query_tokens:
+        best = max((SequenceMatcher(None, query_token, nt).ratio() for nt in name_tokens), default=0.0)
+        token_score = max(token_score, best)
+    return max(whole, token_score)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "normalize_tokens or fuzzy_score" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat: fuzzy scoring primitives for local search"
+```
+
+---
+
+## Task 2: Fuzzy matchers (`_fuzzy_matching_declarations`, `_collect_fuzzy_matches`)
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (add 2 functions after `_body_matching_declarations` / `_collect_matches`)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+from ax_prover.tools.local_lean_search import (
+    _collect_fuzzy_matches,
+    _fuzzy_matching_declarations,
+)
+
+
+def test_fuzzy_matching_declarations_finds_close_name():
+    content = "def extract_min : Nat := 0\ndef heapify : Nat := 1\n"
+    matches = _fuzzy_matching_declarations(content, "extractmin")
+    names = [qualified for _simple, qualified, _occ, _score in matches]
+    assert "extract_min" in names
+    assert "heapify" not in names
+
+
+def test_collect_fuzzy_matches_sorts_by_score_and_caps(tmp_path):
+    (tmp_path / "Def.lean").write_text(
+        "def decrease_key : Nat := 0\ndef decrease_min : Nat := 1\ndef unrelated : Nat := 2\n",
+        encoding="utf-8",
+    )
+    files = [(Path("Def.lean"), (tmp_path / "Def.lean").read_text(encoding="utf-8"))]
+    results = _collect_fuzzy_matches(files, "decrease_mn", SearchLeanLocalConfig(max_results=1))
+    assert len(results) == 1  # cap respected
+    assert results[0][0] == "decrease_min"  # closest by score ranked first
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "fuzzy_matching_declarations or collect_fuzzy" -v`
+Expected: FAIL — `ImportError: cannot import name '_collect_fuzzy_matches'`.
+
+- [ ] **Step 3: Implement the matchers**
+
+Add after `_body_matching_declarations` in `src/ax_prover/tools/local_lean_search.py`:
+
+```python
+def _fuzzy_matching_declarations(
+    content: str, query: str, threshold: float = FUZZY_THRESHOLD
+) -> list[tuple[str, str, int, float]]:
+    """`(simple_name, qualified_name, occurrence, score)` for declarations whose name is a close
+    fuzzy match to `query` (score >= threshold). De-duplicated by qualified name, source order.
+    """
+    if not query.strip():
+        return []
+    results: list[tuple[str, str, int, float]] = []
+    seen: set[str] = set()
+    for declaration, qualified, occurrence in _iter_searchable(content):
+        if qualified in seen:
+            continue
+        score = _fuzzy_score(query, qualified)
+        if score >= threshold:
+            seen.add(qualified)
+            results.append((declaration.name, qualified, occurrence, score))
+    return results
+```
+
+Add after `_collect_matches`:
+
+```python
+def _collect_fuzzy_matches(
+    files: list[tuple[Path, str]], query: str, config: SearchLeanLocalConfig
+) -> list[tuple[str, str, list[tuple[Path, int]]]]:
+    """Group fuzzy matches across files, ranked by descending score, capped to `max_results`."""
+    grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
+    scores: dict[str, float] = {}
+    for relative_path, content in files:
+        for simple_name, qualified_name, occurrence, score in _fuzzy_matching_declarations(
+            content, query
+        ):
+            block = extract_function_from_content(content, simple_name, occurrence)
+            if block is None:
+                continue
+            line = _declaration_line(content, simple_name, occurrence)
+            grouped.setdefault((qualified_name, block), []).append((relative_path, line))
+            scores[qualified_name] = max(scores.get(qualified_name, 0.0), score)
+    results = [(name, block, locations) for (name, block), locations in grouped.items()]
+    results.sort(key=lambda result: scores.get(result[0], 0.0), reverse=True)
+    return results[: config.max_results]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "fuzzy_matching_declarations or collect_fuzzy" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat: fuzzy declaration matchers for local search"
+```
+
+---
+
+## Task 3: Fuzzy header in `_format_results`
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (`_format_results` signature + header/note)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+from ax_prover.tools.local_lean_search import _format_results
+
+
+def test_format_results_fuzzy_header():
+    decls = [("extract_min", "def extract_min := 0", [(Path("Def.lean"), 1)])]
+    out = _format_results("extractmin", decls, SearchLeanLocalConfig(), fuzzy=True)
+    assert "No exact match" in out
+    assert "extractmin" in out
+    assert "fuzzy match" in out
+
+
+def test_format_results_default_header_unchanged():
+    decls = [("foo", "def foo := 0", [(Path("Def.lean"), 1)])]
+    out = _format_results("foo", decls, SearchLeanLocalConfig())
+    assert out.startswith('Found 1 declaration(s) matching "foo":')
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "format_results_fuzzy or format_results_default" -v`
+Expected: FAIL — `_format_results() got an unexpected keyword argument 'fuzzy'`.
+
+- [ ] **Step 3: Add the `fuzzy` flag**
+
+In `_format_results`, change the signature from:
+
+```python
+def _format_results(
+    query: str,
+    declarations: list[tuple[str, str, list[tuple[Path, int]]]],
+    config: SearchLeanLocalConfig,
+    body_match: bool = False,
+) -> str:
+```
+
+to add `fuzzy: bool = False`:
+
+```python
+def _format_results(
+    query: str,
+    declarations: list[tuple[str, str, list[tuple[Path, int]]]],
+    config: SearchLeanLocalConfig,
+    body_match: bool = False,
+    fuzzy: bool = False,
+) -> str:
+```
+
+Then replace the two lines that currently set `header` and `note`:
+
+```python
+    header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+    note = " (matched in body)" if body_match else ""
+```
+
+with:
+
+```python
+    if fuzzy:
+        header = f'No exact match for "{query}". Closest declaration(s):'
+        note = " (fuzzy match)"
+    elif body_match:
+        header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+        note = " (matched in body)"
+    else:
+        header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+        note = ""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "format_results" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat: fuzzy header rendering in _format_results"
+```
+
+---
+
+## Task 4: Insert the fuzzy tier into `_search_root` and update descriptions
+
+**Files:**
+- Modify: `src/ax_prover/tools/local_lean_search.py` (`_search_root` tier order; tool + `query` description)
+- Test: `tests/unit/tools/test_local_lean_search.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/tools/test_local_lean_search.py`:
+
+```python
+def test_search_root_exact_match_wins_no_fuzzy(tmp_path):
+    (tmp_path / "Def.lean").write_text("def extract_min : Nat := 0\n", encoding="utf-8")
+    text, decls = _search_root(tmp_path, "extract_min", SearchLeanLocalConfig())
+    assert "No exact match" not in text
+    assert text.startswith('Found 1 declaration(s) matching "extract_min":')
+    assert len(decls) == 1
+
+
+def test_search_root_fuzzy_fires_on_exact_miss(tmp_path):
+    (tmp_path / "Def.lean").write_text("def extract_min : Nat := 0\n", encoding="utf-8")
+    # "extractmin" is NOT a substring of "extract_min" (underscore) -> exact miss -> fuzzy.
+    text, decls = _search_root(tmp_path, "extractmin", SearchLeanLocalConfig())
+    assert "No exact match" in text
+    assert "extract_min" in text
+    assert decls and decls[0][0] == "extract_min"
+
+
+def test_search_root_body_fallback_when_fuzzy_also_misses(tmp_path):
+    # Name doesn't match query at all, but the identifier appears inside another decl's body.
+    (tmp_path / "Def.lean").write_text(
+        "def helper_token : Nat := 0\ndef wrapper : Nat := helper_token + 1\n",
+        encoding="utf-8",
+    )
+    text, decls = _search_root(tmp_path, "helper_token", SearchLeanLocalConfig())
+    # exact name match on 'helper_token' exists, so this returns exact — adjust to a body-only case:
+    text2, decls2 = _search_root(tmp_path, "zzz_no_name_zzz", SearchLeanLocalConfig())
+    assert "No declarations matching" in text2
+    assert decls2 == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -k "search_root_exact_match_wins or search_root_fuzzy_fires" -v`
+Expected: FAIL — `test_search_root_fuzzy_fires_on_exact_miss` fails (no "No exact match"; current code returns the no-match string for "extractmin").
+
+- [ ] **Step 3: Insert the fuzzy tier**
+
+In `_search_root`, between the exact-name block and the body block, add the fuzzy tier. The function body becomes:
+
+```python
+    files = _read_lean_files(root)
+    decls = _collect_matches(files, query, body=False)
+    if decls:
+        logger.info(f"{label}: Found {len(decls)} declarations for '{query}' under {root}")
+        return _format_results(query, decls, config), decls
+    fuzzy_decls = _collect_fuzzy_matches(files, query, config)
+    if fuzzy_decls:
+        logger.info(f"{label}: Found {len(fuzzy_decls)} fuzzy matches for '{query}' under {root}")
+        return _format_results(query, fuzzy_decls, config, fuzzy=True), fuzzy_decls
+    body_decls = _collect_matches(files, query, body=True)
+    if body_decls:
+        logger.info(f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}")
+        return _format_results(query, body_decls, config, body_match=True), body_decls
+    logger.info(f"{label}: No results for '{query}'")
+    return f'No declarations matching "{query}" found.', []
+```
+
+- [ ] **Step 4: Update the tool and query descriptions**
+
+In `create_search_lean_local_tool`, append a sentence to the `description` string (after the "Treap insert finds Treap.insert" paragraph):
+
+```
+If no name matches your keyword exactly, the closest declaration names are returned as fuzzy suggestions.
+```
+
+In `LocalLeanSearchInput`, append to the `query` field description:
+
+```
+ If nothing matches exactly, the closest names are returned as suggestions.
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/unit/tools/test_local_lean_search.py -q`
+Expected: PASS (full file green, including the WS1 tests carried over).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ax_prover/tools/local_lean_search.py tests/unit/tools/test_local_lean_search.py
+git commit -m "feat: fuzzy fallback tier in local search _search_root"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Run the whole unit suite**
+
+Run: `.venv/bin/pytest tests/unit -q`
+Expected: PASS (no regressions).
+
+- [ ] **Step 2: Lint and format**
+
+Run: `.venv/bin/ruff format . && .venv/bin/ruff check --fix .`
+Expected: "All checks passed!" Commit any formatting:
+
+```bash
+git add -A && git commit -m "style: ruff format/lint" || echo "nothing to format"
+```
+
+- [ ] **Step 3: Push and open the PR into `local-lean-search-tool`**
+
+```bash
+git push -u origin ws2-local-search-fuzzy-fallback
+gh pr create --base local-lean-search-tool --title "feat: fuzzy fallback matching for local search (WS2)" --body "$(cat <<'EOF'
+Adds a fuzzy fallback tier to the local Lean search tool: exact name match → (new) fuzzy match → body-identifier match. Fuzzy fires only on an exact miss, returns the closest declaration names under a "No exact match" header, and is capped by the existing result/char budget so it never bloats context.
+
+Spec: docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** WS2 components map to Task 1 (`_normalize_tokens`/`_fuzzy_score`), Task 2 (`_fuzzy_matching_declarations`/`_collect_fuzzy_matches`), Task 3 (`_format_results` fuzzy header), Task 4 (tier order + descriptions). Tier ordering "exact → fuzzy → body" verified in Task 4 tests; cap respected in Task 2 test.
+- **Type consistency:** `_collect_fuzzy_matches` returns the same `(qualified_name, block, locations)` shape as `_collect_matches`, so `_format_results` and the `_search_root` decls contract (from WS1) are unchanged. `_fuzzy_matching_declarations` carries an extra `score` element used only internally by `_collect_fuzzy_matches`.
+- **WS1 dependency:** assumes `_search_root` already returns `(text, decls)` (WS1). Task 4's body re-states all return paths as tuples, so it is correct whether or not the reviewer re-reads WS1.
+- **Test note:** `test_search_root_body_fallback_when_fuzzy_also_misses` asserts the genuine no-match path (`zzz_no_name_zzz`) returns the empty result, since any close name would otherwise be caught by the fuzzy tier.

--- a/docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md
+++ b/docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md
@@ -1,0 +1,215 @@
+# Local-search efficiency & recall — Design
+
+**Date:** 2026-06-08
+**Branch:** features off `local-lean-search-tool` (a.k.a. "local search"); each merged back into
+`local-lean-search-tool`, which then merges into the experiment branch `run_AI4Math_Challange`.
+
+## Motivation
+
+An experiment run (3 challenges: Dijkstra_3, Kruskal, BinaryHeap_2) surfaced two problems with the
+**local Lean project search** tool (`search_lean_local`):
+
+1. **Extreme redundancy / context bloat.** The agent re-queried the same local definitions
+   (`extract_min`, `heapify`, `IsMST`, …) in almost every iteration. Root cause (confirmed in
+   `agent.py` / `utils/llm.py`): each proposer iteration runs a *fresh* `agentic_loop` whose
+   intermediate `ToolMessage`s are discarded — only the final proposal survives into graph state.
+   So previously-fetched definitions are genuinely absent from the next iteration's context, and the
+   agent is *structurally forced* to re-search them. This repeated flooding of large definitions was
+   identified as the primary trigger for `missing_target_theorem` failures (the LLM loses track of
+   formatting/structure constraints under the bloat).
+
+2. **No fuzzy matching.** Matching requires every query token to be a literal substring of the
+   declaration's qualified name. When the agent guessed a wrong name (e.g. `decrease_priority` for a
+   function actually named differently), it got zero results and had to keep guessing.
+
+This is **not** a Mathlib problem. The remote Mathlib `lean_search` tool does not exhibit this
+redundancy, and Mathlib definitions are never gathered by anything below — only **local project**
+declarations are in scope.
+
+## Scope
+
+Two independent workstreams, two separate PRs:
+
+- **WS1 — Used-definition caching.** Eliminate redundant re-querying by persisting, verbatim, the
+  local-search results the proof actually used.
+- **WS2 — Fuzzy fallback matching.** Add recall when the agent guesses a wrong name, without
+  polluting good exact searches or inflating context.
+
+Both branch off `local-lean-search-tool`. They both touch `_search_root`, so they are sequenced
+**WS1 → WS2** (WS2 rebases on WS1).
+
+---
+
+## WS1 — Used-definition caching
+
+### Principle
+
+Cache the **intersection of two sets**, accumulated across the whole run:
+
+1. **Local-search results returned this run** — i.e. declarations the `search_lean_local` tool
+   actually surfaced. This is the repetitive payload and the real source of bloat. (CSLib and remote
+   Mathlib results are explicitly *not* recorded.)
+2. **Declarations actually used in the proposed code** — the relevance filter.
+
+The cache is therefore *"local-search results that the proof actually referenced."* This naturally
+excludes:
+- Mathlib / remote search results (never recorded).
+- Challenge-file-local helpers the agent never searched for (already visible in the prompt, which
+  always carries the complete challenge file).
+- Search results the agent looked at but never used.
+
+### Accumulation guarantee (critical)
+
+The cache is **append-only across iterations**. Each memory step reads the prior
+`state.used_definitions`, adds any newly used-and-returned definitions, and writes back the **union**
+(deduped by qualified name). A definition captured in iteration 2 remains available through every
+later iteration even if a subsequent attempt stops referencing it. The list is **never wiped**.
+
+### Components
+
+1. **Searcher records its results.**
+   `LocalLeanSearcher` gains `returned_declarations: dict[str, tuple[str, Path, int]]` keyed by
+   qualified name → `(block, path, line)`, populated on every `search()` call. To obtain the
+   structured results, `_search_root(...)` is changed to return `(text, decls)` instead of just
+   `text`, where `decls` is the same list of `(qualified_name, block, locations)` tuples it formats
+   (whichever tier — exact, fuzzy, or body — produced the returned results). The searcher derives
+   each pool entry from a decl's qualified name + block + its first location.
+   - `CslibSearcher.search` unpacks and **ignores** `decls` (so CSLib results never enter any cache).
+   - `LocalLeanSearcher.search` merges `decls` into `self.returned_declarations`.
+   - The instance persists across iterations (tools are created once at agent setup), so the pool
+     accumulates naturally over the run.
+
+2. **Agent captures the live searcher.**
+   After `_create_tools()`, the agent locates the local-search tool in `self.proposer_tools` by name
+   (`tool_name_from_type(LOCAL_LEAN_SEARCH_TOOL_TYPE)`) and stores the bound searcher instance as
+   `self._local_searcher` (via the tool's bound `func.__self__`). If local search is not configured,
+   `self._local_searcher is None` and the entire feature is a clean no-op.
+
+3. **State field.**
+   `ProverAgentState.used_definitions: dict[str, str]` (default empty). Maps qualified name → the
+   rendered verbatim entry (location header + source block). Overwrite semantics at the graph level:
+   the memory node returns the full merged dict each iteration.
+
+4. **Memory-node augmentation (deterministic, no LLM).**
+   `_memory_processor_node` calls `self.memory.process(state)` as today, then merges in
+   `self._accumulate_used_definitions(state)`:
+   - If `self._local_searcher is None` or there is no `last_proposal`/`location`, return the existing
+     `used_definitions` unchanged.
+   - Read `pool = self._local_searcher.returned_declarations` and `code = state.last_proposal.code`.
+   - Start from `dict(state.used_definitions)` (the accumulation base).
+   - For each `(qualified, (block, path, line))` in the pool not already cached: skip if it is the
+     target theorem's own name; otherwise include it iff the declaration is referenced in `code` as a
+     whole identifier — checking both the qualified name and its final dotted segment (the source
+     simple name) via `_identifier_match`. Respect caps (below).
+   - Return the merged dict under key `"used_definitions"`.
+   - This runs **independent of the configured memory strategy** (works even with
+     `MemorylessProcessor`) and **bypasses the experience-summarizer LLM**, so Lean source stays
+     byte-exact (a paraphrased definition would cause "unknown identifier" miscites).
+
+5. **Proposer injection.**
+   In `_proposer_node`, when `state.used_definitions` is non-empty, append a rendered
+   `<local-definitions>` section to the query (after the experience block). Add one line to the
+   proposer system prompt(s): definitions already used are provided in `<local-definitions>` and must
+   not be re-searched.
+
+   Rendered shape:
+   ```
+   <local-definitions>
+   These project definitions were referenced in your previous attempts and are provided verbatim,
+   so you do NOT need to search for them again:
+
+   -- <qualified_name> — <path>:<line>
+   <verbatim block>
+
+   -- <qualified_name> — <path>:<line>
+   <verbatim block>
+   </local-definitions>
+   ```
+
+6. **Caps (module constants, promotable to config later).**
+   `MAX_CACHED_DEFINITIONS` (≈24) and `MAX_CACHED_DEFINITION_CHARS` (≈12000) bound growth. When a cap
+   is reached, stop adding new definitions (already-cached ones are retained — accumulation is never
+   reduced).
+
+### Files (WS1)
+
+- `src/ax_prover/tools/local_lean_search.py` — `returned_declarations` on `LocalLeanSearcher`;
+  `_search_root` returns `(text, decls)`; caps constants; a small render helper for cached entries.
+- `src/ax_prover/tools/cslib_search.py` — unpack `(text, _)` from `_search_root`.
+- `src/ax_prover/models/proving.py` — `used_definitions: dict[str, str]` field.
+- `src/ax_prover/prover/agent.py` — capture `self._local_searcher`; `_accumulate_used_definitions`;
+  `_memory_processor_node` merge; proposer injection of `<local-definitions>`.
+- `src/ax_prover/prover/prompts.py` — `<local-definitions>` template + system-prompt nudge.
+
+### Tests (WS1, TDD)
+
+- `_search_root` returns both text and structured decls for exact / fuzzy / body tiers; CSLib path
+  unpacks without error and records nothing.
+- `LocalLeanSearcher.returned_declarations` accumulates across multiple `search()` calls and dedups.
+- `_accumulate_used_definitions`:
+  - caches a pooled def referenced in the code (whole-identifier), with location header;
+  - ignores a pooled def **not** referenced in the code;
+  - excludes the target theorem's own name;
+  - is monotonic — a def cached in an earlier step survives a later step whose code no longer uses it;
+  - respects `MAX_CACHED_DEFINITIONS` / `MAX_CACHED_DEFINITION_CHARS`;
+  - is a no-op when `self._local_searcher is None`.
+- Proposer injects `<local-definitions>` into the query when `used_definitions` is non-empty
+  (source-level guard that the wiring exists, mirroring existing proposer-wiring tests).
+
+---
+
+## WS2 — Fuzzy fallback matching
+
+### Behavior
+
+A new matching tier inside `_search_root`, **firing only when exact name matching returns zero**:
+
+```
+exact name match  →  (NEW) fuzzy name match  →  body-identifier match
+```
+
+This keeps exact searches clean and fast and only spends recall effort on a genuine miss — important
+because WS1's whole purpose is reducing context bloat, so fuzzy must not blend approximate matches
+into otherwise-good exact results.
+
+### Components
+
+- `_fuzzy_name_matches(names, query, threshold)`: normalize both candidate names and the query
+  (case-fold; split on `.`, `_`, and camelCase boundaries into token sequences); score with
+  `difflib.SequenceMatcher` ratio combined with token-set overlap; keep the top-N candidates above a
+  threshold (≈0.6). Returns the same `(simple_name, qualified_name, occurrence)` tuple shape the
+  existing tiers use, so `_collect_matches`-style grouping and `_format_results` are reused.
+- `_format_results` gains a fuzzy flag that renders a clear header:
+  `No exact match — closest names:` (analogous to the existing `body_match` note). Capped by the same
+  `max_results` / `max_chars` budget so it cannot bloat context.
+- Tool description and the `query` field description mention the fuzzy fallback.
+
+### Files (WS2)
+
+- `src/ax_prover/tools/local_lean_search.py` — `_fuzzy_name_matches`, normalization helper, fuzzy
+  tier in `_search_root`, `_format_results` fuzzy label, tool/`query` description updates.
+
+### Tests (WS2, TDD)
+
+- Exact match still wins — no fuzzy results when an exact substring match exists.
+- Fuzzy fires only on an exact miss; a near-miss query (e.g. `extractmin` → `extract_min`, or a typo
+  `decrese_min` → `decrease_min`) surfaces the closest names under the `No exact match` header.
+- Body-identifier fallback still works when both exact and fuzzy miss.
+- Fuzzy results respect the result/char caps.
+
+---
+
+## Out of scope / non-goals
+
+- No change to the Mathlib remote `lean_search` tool or the CSLib `search_cslib` tool behavior
+  (CSLib only loses the now-unused second tuple element from `_search_root`).
+- No change to import/opens handling, the `restrict_to_proof_body` lock, or the reviewer.
+- Caps are not surfaced as config in this iteration (constants only).
+
+## Branching & sequencing
+
+1. Branch `wsX` off `local-lean-search-tool` for WS1 → PR into `local-lean-search-tool`.
+2. Branch off the updated `local-lean-search-tool` for WS2 → PR into `local-lean-search-tool`.
+3. Merge `local-lean-search-tool` → `run_AI4Math_Challange` (experiment branch).
+
+`main` is not touched by this work beyond the existing open PR #13 for `local-lean-search-tool`.

--- a/src/ax_prover/models/proving.py
+++ b/src/ax_prover/models/proving.py
@@ -72,6 +72,14 @@ class ProverAgentState(BaseModel):
         description="Context with the key lessons learned from the prover's previous attempts in natural language",
     )
 
+    used_definitions: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Run-scoped cache of local-search definitions the proof actually used, keyed by "
+            "qualified name → rendered verbatim entry. Append-only across iterations."
+        ),
+    )
+
     summary: str = Field(default="", description="LLM-generated summary of the prover run")
 
     @model_validator(mode="before")

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -27,6 +27,12 @@ from ..models.messages import (
 )
 from ..models.proving import ProverResult, ReviewDecision
 from ..tools import create_tool
+from ..tools.local_lean_search import (
+    LOCAL_LEAN_SEARCH_TOOL_TYPE,
+    LocalLeanSearcher,
+    accumulate_used_definitions,
+)
+from ..tools.registry import tool_name_from_type
 from ..utils import (
     attach_builder_files,
     attach_prover_logs_if_enabled,
@@ -55,6 +61,7 @@ from . import memory as memory_module
 from .memory import BaseMemory
 from .prompts import (
     ATTEMPT_TEMPLATE,
+    LOCAL_DEFINITIONS_USER_PROMPT,
     PREVIOUS_ATTEMPT_USER_PROMPT,
     PROPOSER_SYSTEM_PROMPT,
     PROPOSER_SYSTEM_PROMPT_SINGLE_SHOT,
@@ -92,6 +99,7 @@ class ProverAgent:
             self.lean_semaphore = Semaphore(self.runtime_config.lean.max_concurrent_builds)
 
         self.proposer_tools = []
+        self._local_searcher: LocalLeanSearcher | None = None
 
         self.llm_client = LLMClient(self.config.prover_llm)
 
@@ -133,6 +141,7 @@ class ProverAgent:
         )
 
         instance.proposer_tools = await instance._create_tools()
+        instance._local_searcher = instance._find_local_searcher()
         instance.app = instance._build_graph()
 
         return instance
@@ -235,9 +244,33 @@ class ProverAgent:
         half = (self.max_input_tokens - len(message_separator)) // 2
         return f"{message[:half]}{message_separator}{message[-half:]}"
 
+    def _find_local_searcher(self) -> LocalLeanSearcher | None:
+        """Locate the live LocalLeanSearcher behind the local-search tool, if configured."""
+        local_tool_name = tool_name_from_type(LOCAL_LEAN_SEARCH_TOOL_TYPE)
+        for tool in self.proposer_tools:
+            if tool.name == local_tool_name:
+                bound = getattr(getattr(tool, "func", None), "__self__", None)
+                if isinstance(bound, LocalLeanSearcher):
+                    return bound
+        return None
+
+    def _accumulate_used_definitions(self, state: ProverAgentState) -> dict[str, str]:
+        """Append local-search results referenced by the latest proposal to the run cache."""
+        if self._local_searcher is None or not state.last_proposal:
+            return dict(state.used_definitions)
+        target_name = state.item.location.name if state.item.location else None
+        return accumulate_used_definitions(
+            state.used_definitions,
+            self._local_searcher.returned_declarations,
+            state.last_proposal.code,
+            target_name,
+        )
+
     async def _memory_processor_node(self, state: ProverAgentState) -> dict:
-        """Process memory using the configured memory strategy."""
-        return await self.memory.process(state)
+        """Process memory using the configured strategy, plus accumulate used local definitions."""
+        result = await self.memory.process(state)
+        result["used_definitions"] = self._accumulate_used_definitions(state)
+        return result
 
     async def _proposer_node(self, state: ProverAgentState, config: RunnableConfig) -> dict:
         self.logger.info(
@@ -279,6 +312,12 @@ class ProverAgent:
 
         if state.experience:
             query = "\n\n".join([query, state.experience])
+
+        if state.used_definitions:
+            definitions_block = LOCAL_DEFINITIONS_USER_PROMPT.format(
+                definitions="\n\n".join(state.used_definitions.values())
+            )
+            query = "\n\n".join([query, definitions_block])
 
         context_messages = [
             SystemMessage(content=system_prompt),

--- a/src/ax_prover/prover/prompts.py
+++ b/src/ax_prover/prover/prompts.py
@@ -32,6 +32,7 @@ Think carefully about the current proof state and the knowledge gathered from th
 3. **Quality Standards**
     - Use appropriate Lean 4 tactics and syntax
     - When searching for lemmas, match the search tool to the file's imports: if the file imports `Mathlib.*`, use the Mathlib search tool (`search_lean_search_tool`); if it imports `Cslib.*`, use the CSLib search tool (`search_cslib_tool`); for declarations from the project's own modules (any other local imports, neither Mathlib nor CSLib), use the local project search tool (`search_lean_local_tool`).
+    - Project definitions you have already used in previous attempts are provided verbatim in the <local-definitions> section of the message — reference them directly and do NOT search for them again.
     - Add imports as needed for any lemmas or tactics you use
 </requirements>
 
@@ -221,6 +222,14 @@ Complete the proof for the following target theorem within the given file.
 {complete_file}
 ```
 </complete-file>
+"""
+
+LOCAL_DEFINITIONS_USER_PROMPT = """
+These project definitions were referenced in your previous attempts and are provided verbatim, so you do NOT need to search for them again:
+
+<local-definitions>
+{definitions}
+</local-definitions>
 """
 
 REVIEWER_SYSTEM_PROMPT = """

--- a/src/ax_prover/prover/prompts.py
+++ b/src/ax_prover/prover/prompts.py
@@ -32,7 +32,7 @@ Think carefully about the current proof state and the knowledge gathered from th
 3. **Quality Standards**
     - Use appropriate Lean 4 tactics and syntax
     - When searching for lemmas, match the search tool to the file's imports: if the file imports `Mathlib.*`, use the Mathlib search tool (`search_lean_search_tool`); if it imports `Cslib.*`, use the CSLib search tool (`search_cslib_tool`); for declarations from the project's own modules (any other local imports, neither Mathlib nor CSLib), use the local project search tool (`search_lean_local_tool`).
-    - Project definitions you have already used in previous attempts are provided verbatim in the <local-definitions> section of the message — reference them directly and do NOT search for them again.
+    - If a <local-definitions> section is present in the message, the project definitions you have already used are listed there verbatim — reference them directly and do NOT search for them again.
     - Add imports as needed for any lemmas or tactics you use
 </requirements>
 

--- a/src/ax_prover/tools/cslib_search.py
+++ b/src/ax_prover/tools/cslib_search.py
@@ -69,7 +69,8 @@ class CslibSearcher:
         if cslib is None:
             logger.warning(f"CslibSearch: {error}")
             return error
-        return _search_root(cslib, query, self.config, label="CslibSearch")
+        text, _decls = _search_root(cslib, query, self.config, label="CslibSearch")
+        return text
 
 
 class CslibSearchInput(BaseModel):

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -308,23 +308,23 @@ def _collect_matches(
 
 def _search_root(
     root: Path, query: str, config: SearchLeanLocalConfig, *, label: str = "LocalLeanSearch"
-) -> str:
+) -> tuple[str, list[tuple[str, str, list[tuple[Path, int]]]]]:
     """Search `root` by declaration name; fall back to body search only if name finds nothing.
 
-    Walks the tree and reads each file once; the body fallback reuses the cached contents
-    rather than re-walking and re-reading on a name-miss.
+    Returns the formatted text plus the structured declarations it formatted (empty on no match).
+    Walks the tree and reads each file once; the body fallback reuses the cached contents.
     """
     files = _read_lean_files(root)
     decls = _collect_matches(files, query, body=False)
     if decls:
         logger.info(f"{label}: Found {len(decls)} declarations for '{query}' under {root}")
-        return _format_results(query, decls, config)
+        return _format_results(query, decls, config), decls
     body_decls = _collect_matches(files, query, body=True)
     if body_decls:
         logger.info(f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}")
-        return _format_results(query, body_decls, config, body_match=True)
+        return _format_results(query, body_decls, config, body_match=True), body_decls
     logger.info(f"{label}: No results for '{query}'")
-    return f'No declarations matching "{query}" found.'
+    return f'No declarations matching "{query}" found.', []
 
 
 class LocalLeanSearcher:
@@ -371,7 +371,8 @@ class LocalLeanSearcher:
             logger.warning(f"LocalLeanSearch: {error}")
             return error
 
-        return _search_root(root, query, self.config)
+        text, _decls = _search_root(root, query, self.config)
+        return text
 
 
 class LocalLeanSearchInput(BaseModel):

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -36,6 +36,10 @@ LAKE_ROOT_MARKERS = ("lakefile.toml", "lakefile.lean", "lake-manifest.json")
 # Build artifacts + vendored dependencies (Mathlib) live here; never searched.
 EXCLUDED_DIR = ".lake"
 
+# Caps for the run-scoped cache of used local definitions (consumed by the memory node).
+MAX_CACHED_DEFINITIONS = 24
+MAX_CACHED_DEFINITION_CHARS = 12000
+
 # Declaration kinds worth returning. Excludes structural keywords (open, end,
 # namespace, section, import) that DeclarationType also enumerates.
 SEARCHABLE_TYPES = frozenset(
@@ -106,6 +110,50 @@ def _identifier_match(token: str, text: str) -> bool:
     """True if `token` appears in `text` as a whole identifier (case-insensitive)."""
     pattern = rf"(?<!{_IDENT_CHAR}){re.escape(token)}(?!{_IDENT_CHAR})"
     return re.search(pattern, text, re.IGNORECASE) is not None
+
+
+def identifier_in_code(name: str, code: str) -> bool:
+    """True if `name` or its final dotted segment appears in `code` as a whole identifier."""
+    candidates = {name, name.rsplit(".", 1)[-1]}
+    return any(_identifier_match(candidate, code) for candidate in candidates)
+
+
+def format_cached_definition_entry(qualified_name: str, block: str, path: Path, line: int) -> str:
+    """Render one cached definition as a located, verbatim source entry."""
+    return f"-- {qualified_name} — {path}:{line}\n{block}"
+
+
+def accumulate_used_definitions(
+    cached: dict[str, str],
+    returned_declarations: dict[str, tuple[str, Path, int]],
+    code: str,
+    target_name: str | None,
+) -> dict[str, str]:
+    """Append local-search results that `code` actually used to the run-scoped `cached` map.
+
+    Append-only and deduped by qualified name. An entry is added only when the local-search tool
+    returned it (it is in `returned_declarations`) AND it is referenced in `code` as a whole
+    identifier. The target theorem's own simple name is excluded. Respects MAX_CACHED_DEFINITIONS
+    and MAX_CACHED_DEFINITION_CHARS; existing entries are never removed.
+    """
+    merged = dict(cached)
+    total_chars = sum(len(entry) for entry in merged.values())
+    target_simple = target_name.rsplit(".", 1)[-1] if target_name else None
+    for qualified_name, (block, path, line) in returned_declarations.items():
+        if qualified_name in merged:
+            continue
+        if len(merged) >= MAX_CACHED_DEFINITIONS:
+            break
+        if target_simple and qualified_name.rsplit(".", 1)[-1] == target_simple:
+            continue
+        if not identifier_in_code(qualified_name, code):
+            continue
+        entry = format_cached_definition_entry(qualified_name, block, path, line)
+        if total_chars + len(entry) > MAX_CACHED_DEFINITION_CHARS:
+            break
+        merged[qualified_name] = entry
+        total_chars += len(entry)
+    return merged
 
 
 def _iter_lean_files(root: Path) -> Iterator[Path]:

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -385,6 +385,7 @@ class LocalLeanSearcher:
         self.config = config
         self.base_folder = base_folder
         self._resolution: tuple[Path | None, str] | None = None
+        self.returned_declarations: dict[str, tuple[str, Path, int]] = {}
 
     def _resolve_root(self) -> tuple[Path | None, str]:
         if self._resolution is None:
@@ -419,8 +420,17 @@ class LocalLeanSearcher:
             logger.warning(f"LocalLeanSearch: {error}")
             return error
 
-        text, _decls = _search_root(root, query, self.config)
+        text, decls = _search_root(root, query, self.config)
+        self._record_returned(decls)
         return text
+
+    def _record_returned(self, decls: list[tuple[str, str, list[tuple[Path, int]]]]) -> None:
+        """Accumulate returned declarations for the run, keyed by qualified name (first-seen wins)."""
+        for qualified_name, block, locations in decls:
+            if qualified_name in self.returned_declarations or not locations:
+                continue
+            path, line = locations[0]
+            self.returned_declarations[qualified_name] = (block, path, line)
 
 
 class LocalLeanSearchInput(BaseModel):

--- a/tests/unit/prover/test_used_definition_caching.py
+++ b/tests/unit/prover/test_used_definition_caching.py
@@ -1,5 +1,8 @@
 """Tests for the WS1 used-definition caching feature."""
 
+import inspect
+from types import SimpleNamespace
+
 from ax_prover.models.proving import ProverAgentState, TargetItem
 
 
@@ -33,3 +36,42 @@ def test_iterative_system_prompt_mentions_local_definitions():
     from ax_prover.prover.prompts import PROPOSER_SYSTEM_PROMPT
 
     assert "<local-definitions>" in PROPOSER_SYSTEM_PROMPT
+
+
+def test_find_local_searcher_locates_the_searcher(tmp_path):
+    from ax_prover.prover.agent import ProverAgent
+    from ax_prover.tools.local_lean_search import (
+        LocalLeanSearcher,
+        SearchLeanLocalConfig,
+        create_search_lean_local_tool,
+    )
+
+    (tmp_path / "lakefile.toml").write_text('name = "demo"\n', encoding="utf-8")
+    tool = create_search_lean_local_tool(SearchLeanLocalConfig(), base_folder=str(tmp_path))
+    fake = SimpleNamespace(proposer_tools=[tool])
+
+    searcher = ProverAgent._find_local_searcher(fake)
+    assert isinstance(searcher, LocalLeanSearcher)
+
+
+def test_find_local_searcher_returns_none_when_absent():
+    from ax_prover.prover.agent import ProverAgent
+
+    fake = SimpleNamespace(proposer_tools=[])
+    assert ProverAgent._find_local_searcher(fake) is None
+
+
+def test_memory_node_wires_in_accumulation():
+    from ax_prover.prover.agent import ProverAgent
+
+    source = inspect.getsource(ProverAgent._memory_processor_node)
+    assert "_accumulate_used_definitions(" in source
+    assert "used_definitions" in source
+
+
+def test_proposer_node_injects_local_definitions():
+    from ax_prover.prover.agent import ProverAgent
+
+    source = inspect.getsource(ProverAgent._proposer_node)
+    assert "state.used_definitions" in source
+    assert "LOCAL_DEFINITIONS_USER_PROMPT" in source

--- a/tests/unit/prover/test_used_definition_caching.py
+++ b/tests/unit/prover/test_used_definition_caching.py
@@ -18,3 +18,18 @@ def test_used_definitions_accepts_mapping():
         used_definitions={"A.foo": "-- A.foo — Def.lean:1\ndef foo := 1"},
     )
     assert "A.foo" in state.used_definitions
+
+
+def test_local_definitions_prompt_wraps_definitions():
+    from ax_prover.prover.prompts import LOCAL_DEFINITIONS_USER_PROMPT
+
+    rendered = LOCAL_DEFINITIONS_USER_PROMPT.format(definitions="-- A.foo\ndef foo := 1")
+    assert "<local-definitions>" in rendered
+    assert "</local-definitions>" in rendered
+    assert "def foo := 1" in rendered
+
+
+def test_iterative_system_prompt_mentions_local_definitions():
+    from ax_prover.prover.prompts import PROPOSER_SYSTEM_PROMPT
+
+    assert "<local-definitions>" in PROPOSER_SYSTEM_PROMPT

--- a/tests/unit/prover/test_used_definition_caching.py
+++ b/tests/unit/prover/test_used_definition_caching.py
@@ -1,5 +1,6 @@
 """Tests for the WS1 used-definition caching feature."""
 
+import asyncio
 import inspect
 from types import SimpleNamespace
 
@@ -67,6 +68,27 @@ def test_memory_node_wires_in_accumulation():
     source = inspect.getsource(ProverAgent._memory_processor_node)
     assert "_accumulate_used_definitions(" in source
     assert "used_definitions" in source
+
+
+def test_memory_node_preserves_experience_and_adds_used_definitions():
+    """Behavioral: _memory_processor_node keeps the memory strategy's output and adds the cache."""
+    from ax_prover.prover.agent import ProverAgent
+
+    class _StubMemory:
+        async def process(self, state):
+            return {"experience": "LESSON-X"}
+
+    state = ProverAgentState(item=TargetItem(title="t"))  # used_definitions defaults to {}
+
+    fake = SimpleNamespace(memory=_StubMemory(), _local_searcher=None)
+    # Bind the real methods to the fake so the no-op accumulation path runs.
+    fake._accumulate_used_definitions = ProverAgent._accumulate_used_definitions.__get__(fake)
+    bound_node = ProverAgent._memory_processor_node.__get__(fake)
+
+    result = asyncio.run(bound_node(state))
+
+    assert result["experience"] == "LESSON-X"  # memory strategy output preserved
+    assert result["used_definitions"] == {}  # cache added (empty: no searcher / no proposal)
 
 
 def test_proposer_node_injects_local_definitions():

--- a/tests/unit/prover/test_used_definition_caching.py
+++ b/tests/unit/prover/test_used_definition_caching.py
@@ -1,0 +1,20 @@
+"""Tests for the WS1 used-definition caching feature."""
+
+from ax_prover.models.proving import ProverAgentState, TargetItem
+
+
+def _state() -> ProverAgentState:
+    return ProverAgentState(item=TargetItem(title="t"))
+
+
+def test_used_definitions_defaults_to_empty_dict():
+    state = _state()
+    assert state.used_definitions == {}
+
+
+def test_used_definitions_accepts_mapping():
+    state = ProverAgentState(
+        item=TargetItem(title="t"),
+        used_definitions={"A.foo": "-- A.foo — Def.lean:1\ndef foo := 1"},
+    )
+    assert "A.foo" in state.used_definitions

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -17,6 +17,7 @@ from ax_prover.tools.local_lean_search import (
     _identifier_match,
     _iter_lean_files,
     _matching_declaration_names,
+    _search_root,
     _walk_down_for_roots,
     _walk_up_for_root,
 )
@@ -563,6 +564,28 @@ class TestBodyMatchingDeclarations:
     def test_body_search_respects_identifier_boundary(self):
         # 'quer' is a prefix, not a whole identifier in the body -> no match.
         assert _body_matching_declarations(WHERE_BLOCK_LEAN, "quer") == []
+
+
+def _write(tmp_path: Path, name: str, text: str) -> None:
+    (tmp_path / name).write_text(text, encoding="utf-8")
+
+
+def test_search_root_returns_text_and_decls_on_name_match(tmp_path):
+    _write(tmp_path, "Def.lean", "def extract_min : Nat := 0\n")
+    text, decls = _search_root(tmp_path, "extract_min", SearchLeanLocalConfig())
+    assert "extract_min" in text
+    assert len(decls) == 1
+    qualified_name, block, locations = decls[0]
+    assert qualified_name == "extract_min"
+    assert "def extract_min" in block
+    assert locations and locations[0][1] == 1  # (path, line)
+
+
+def test_search_root_returns_empty_decls_on_no_match(tmp_path):
+    _write(tmp_path, "Def.lean", "def foo : Nat := 0\n")
+    text, decls = _search_root(tmp_path, "nonexistent_name", SearchLeanLocalConfig())
+    assert "No declarations matching" in text
+    assert decls == []
 
 
 @pytest.fixture

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -739,6 +739,19 @@ def test_searcher_accumulates_returned_declarations_across_calls(tmp_path):
     assert set(searcher.returned_declarations) == {"extract_min", "heapify"}
 
 
+def test_searcher_first_seen_wins_on_repeat_search(tmp_path):
+    root = _make_lake_project(tmp_path)
+    (root / "Def.lean").write_text(
+        "def extract_min : Nat := 0\ndef heapify : Nat := 1\n", encoding="utf-8"
+    )
+    searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root))
+    searcher.search("extract_min")
+    first_value = searcher.returned_declarations["extract_min"]
+    # Searching the same name again must not replace the recorded entry.
+    searcher.search("extract_min")
+    assert searcher.returned_declarations["extract_min"] == first_value
+
+
 def test_searcher_records_nothing_on_miss(tmp_path):
     root = _make_lake_project(tmp_path)
     (root / "Def.lean").write_text(

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -720,3 +720,30 @@ def test_accumulate_none_target_still_adds_used_definition():
         cached={}, returned_declarations=returned, code=code, target_name=None
     )
     assert "BinaryHeap.extract_min" in result
+
+
+def test_searcher_accumulates_returned_declarations_across_calls(tmp_path):
+    root = _make_lake_project(tmp_path)
+    (root / "Def.lean").write_text(
+        "def extract_min : Nat := 0\ndef heapify : Nat := 1\n", encoding="utf-8"
+    )
+    searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root))
+
+    searcher.search("extract_min")
+    assert "extract_min" in searcher.returned_declarations
+    block, path, line = searcher.returned_declarations["extract_min"]
+    assert "def extract_min" in block
+
+    searcher.search("heapify")
+    # First result is retained; second is added (accumulation, not replacement).
+    assert set(searcher.returned_declarations) == {"extract_min", "heapify"}
+
+
+def test_searcher_records_nothing_on_miss(tmp_path):
+    root = _make_lake_project(tmp_path)
+    (root / "Def.lean").write_text(
+        "def extract_min : Nat := 0\ndef heapify : Nat := 1\n", encoding="utf-8"
+    )
+    searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root))
+    searcher.search("totally_absent_name")
+    assert searcher.returned_declarations == {}

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -9,6 +9,7 @@ from ax_prover.models.declaration import DeclarationType
 from ax_prover.tools import create_search_lean_local_tool
 from ax_prover.tools.local_lean_search import (
     LOCAL_LEAN_SEARCH_TOOL_TYPE,
+    MAX_CACHED_DEFINITIONS,
     SEARCHABLE_TYPES,
     LocalLeanSearcher,
     SearchLeanLocalConfig,
@@ -20,6 +21,9 @@ from ax_prover.tools.local_lean_search import (
     _search_root,
     _walk_down_for_roots,
     _walk_up_for_root,
+    accumulate_used_definitions,
+    format_cached_definition_entry,
+    identifier_in_code,
 )
 from ax_prover.tools.registry import TOOL_REGISTRY
 
@@ -634,3 +638,69 @@ class TestBodySearchEndToEnd:
         assert "matched in body" in out
         assert read_counts  # at least one .lean file was read
         assert all(count == 1 for count in read_counts.values()), read_counts
+
+
+def test_identifier_in_code_matches_qualified_and_simple():
+    assert identifier_in_code("BinaryHeap.extract_min", "  exact extract_min h")
+    assert identifier_in_code("BinaryHeap.extract_min", "  exact BinaryHeap.extract_min h")
+    assert not identifier_in_code(
+        "extract_min", "  exact extract_minimum h"
+    )  # not whole-identifier
+    assert not identifier_in_code("heapify", "  simp")
+
+
+def test_format_cached_definition_entry_has_location_header_and_block():
+    entry = format_cached_definition_entry("A.foo", "def foo := 1", Path("Def.lean"), 3)
+    assert entry == "-- A.foo — Def.lean:3\ndef foo := 1"
+
+
+def _pool():
+    return {
+        "BinaryHeap.extract_min": ("def extract_min : Nat := 0", Path("Def.lean"), 5),
+        "BinaryHeap.heapify": ("def heapify : Nat := 1", Path("Def.lean"), 9),
+    }
+
+
+def test_accumulate_adds_only_used_definitions():
+    code = "theorem t : True := by have := extract_min; trivial"
+    result = accumulate_used_definitions({}, _pool(), code, target_name="t")
+    assert "BinaryHeap.extract_min" in result
+    assert "BinaryHeap.heapify" not in result  # returned but not used in code
+
+
+def test_accumulate_excludes_target_by_simple_name():
+    pool = {"Foo.extract_min": ("def extract_min := 0", Path("Def.lean"), 1)}
+    code = "theorem extract_min : True := by exact extract_min"
+    result = accumulate_used_definitions({}, pool, code, target_name="extract_min")
+    assert result == {}  # the only candidate shares the target's simple name
+
+
+def test_accumulate_is_monotonic_and_dedups():
+    prior = {"BinaryHeap.heapify": "-- cached earlier"}
+    code = "theorem t : True := by exact extract_min"  # heapify NOT used now
+    result = accumulate_used_definitions(prior, _pool(), code, target_name="t")
+    assert result["BinaryHeap.heapify"] == "-- cached earlier"  # preserved, not wiped
+    assert "BinaryHeap.extract_min" in result  # newly used, added
+    again = accumulate_used_definitions(result, _pool(), code, target_name="t")
+    assert again == result
+
+
+def test_accumulate_respects_count_cap():
+    pool = {
+        f"N.def_{i}": (f"def def_{i} := {i}", Path("Def.lean"), i + 1)
+        for i in range(MAX_CACHED_DEFINITIONS + 5)
+    }
+    code = " ".join(f"def_{i}" for i in range(MAX_CACHED_DEFINITIONS + 5))
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert len(result) == MAX_CACHED_DEFINITIONS
+
+
+def test_accumulate_respects_char_cap():
+    big_block = "x" * 9000  # two of these exceed the 12000-char cap
+    pool = {
+        "N.a": (big_block, Path("Def.lean"), 1),
+        "N.b": (big_block, Path("Def.lean"), 2),
+    }
+    code = "a b"  # both 'a' and 'b' referenced as whole identifiers
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert len(result) == 1  # second entry would blow the char budget

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -704,3 +704,19 @@ def test_accumulate_respects_char_cap():
     code = "a b"  # both 'a' and 'b' referenced as whole identifiers
     result = accumulate_used_definitions({}, pool, code, target_name="t")
     assert len(result) == 1  # second entry would blow the char budget
+
+
+def test_accumulate_none_target_and_empty_pool_are_safe():
+    # None target_name must not crash; empty returned_declarations returns the cache unchanged.
+    assert accumulate_used_definitions({}, {}, "some code", None) == {}
+    prior = {"A.foo": "-- A.foo — Def.lean:1\ndef foo := 1"}
+    assert accumulate_used_definitions(prior, {}, "foo", None) == prior
+
+
+def test_accumulate_none_target_still_adds_used_definition():
+    returned = {"BinaryHeap.extract_min": ("def extract_min : Nat := 0", Path("Def.lean"), 5)}
+    code = "theorem t : True := by exact extract_min"
+    result = accumulate_used_definitions(
+        cached={}, returned_declarations=returned, code=code, target_name=None
+    )
+    assert "BinaryHeap.extract_min" in result


### PR DESCRIPTION
Caches, verbatim and append-only, the local-search results the proof actually used, and injects them into each subsequent proposer prompt so the agent stops re-querying the same definitions every iteration (the redundancy that flooded context and triggered `missing_target_theorem` failures in the last experiment run).

## How it works
- `LocalLeanSearcher` records every declaration it returns for the run (`returned_declarations`, first-seen wins).
- The memory node (runs on the retry path between attempts) intersects that pool with the identifiers actually used in the proposed code (`accumulate_used_definitions`), excludes the target theorem, and appends to a new append-only `used_definitions` state field — never wiped, deduped, capped (24 defs / 12000 chars).
- The proposer renders a `<local-definitions>` block into its query; the verbatim Lean source bypasses the experience-summarizer LLM so it can't be paraphrased into "unknown identifier" miscites.
- CSLib/Mathlib search results are never cached. Clean no-op when local search isn't configured or in single-shot mode.

## Tests
371 unit tests pass; ruff clean. New coverage: pure-helper behavior (used/not-used, target exclusion, monotonicity, both caps, None target, empty pool), searcher recording + first-seen-wins, the field default, the prompt template/nudge, `_find_local_searcher` introspection, and a behavioral test that the memory node preserves `experience` while adding `used_definitions`.

Spec: `docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md`
Plan: `docs/superpowers/plans/2026-06-08-ws1-local-search-used-definition-caching.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the prover retry path (memory + proposer prompts and graph state) and grows prompt size when the cache fills, but logic is deterministic, capped, and no-ops without local search; Mathlib/CSLib are excluded.
> 
> **Overview**
> Adds **WS1 used-definition caching** so the iterative prover stops re-fetching the same local Lean declarations every iteration.
> 
> **Local search:** `_search_root` now returns `(formatted text, structured decls)`. `LocalLeanSearcher` accumulates `returned_declarations` per run (first-seen wins). Pure helpers (`identifier_in_code`, `accumulate_used_definitions`, etc.) intersect that pool with identifiers actually used in the latest proposal, with caps (24 defs / 12k chars) and target-theorem exclusion. CSLib search unpacks the tuple but does not cache.
> 
> **Agent graph:** New `ProverAgentState.used_definitions` is updated deterministically in `_memory_processor_node` (alongside the existing memory strategy, no LLM). `_proposer_node` appends a `<local-definitions>` block via `LOCAL_DEFINITIONS_USER_PROMPT`, and the iterative system prompt tells the model not to re-search those entries. No-op when local search is not configured.
> 
> **Docs:** Adds the design spec and implementation plans for WS1 and the follow-on **WS2 fuzzy fallback** (not implemented in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff9ae1bf5b5adcac8d773fbf75e7f7368b3dff11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->