### PR TITLE
feat: fuzzy fallback matching for local search (WS2)

### DIFF
--- a/docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md
+++ b/docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md
@@ -162,11 +162,18 @@ later iteration even if a subsequent attempt stops referencing it. The list is *
 
 ### Behavior
 
-A new matching tier inside `_search_root`, **firing only when exact name matching returns zero**:
+A new matching tier inside `_search_root`, **firing only when both exact name matching and the
+body-identifier fallback return zero**:
 
 ```
-exact name match  →  (NEW) fuzzy name match  →  body-identifier match
+exact name match  →  body-identifier match  →  (NEW) fuzzy name match
 ```
+
+> **Implementation note:** the tier order was refined during implementation from the originally
+> planned exact → fuzzy → body to **exact → body → fuzzy**. A body-identifier match is an *exact*
+> hit (the literal identifier appears inside a declaration's body, e.g. a `where`-helper), so it
+> should outrank an *approximate* fuzzy name guess. Fuzzy is therefore the true last resort before
+> a genuine no-match.
 
 This keeps exact searches clean and fast and only spends recall effort on a genuine miss — important
 because WS1's whole purpose is reducing context bloat, so fuzzy must not blend approximate matches
@@ -180,8 +187,9 @@ into otherwise-good exact results.
   threshold (≈0.6). Returns the same `(simple_name, qualified_name, occurrence)` tuple shape the
   existing tiers use, so `_collect_matches`-style grouping and `_format_results` are reused.
 - `_format_results` gains a fuzzy flag that renders a clear header:
-  `No exact match — closest names:` (analogous to the existing `body_match` note). Capped by the same
-  `max_results` / `max_chars` budget so it cannot bloat context.
+  `No exact match for "<query>". Closest declaration(s):` (analogous to the existing `body_match`
+  note, plus a per-entry `(fuzzy match)` marker). Capped by the same `max_results` / `max_chars`
+  budget so it cannot bloat context.
 - Tool description and the `query` field description mention the fuzzy fallback.
 
 ### Files (WS2)

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -121,25 +121,28 @@ def _normalize_tokens(name: str) -> list[str]:
 def _fuzzy_score(query: str, name: str) -> float:
     """Similarity in [0, 1] between `query` and a declaration's (final) name.
 
-    Blends a whole-string ratio (ignoring underscores) with the best per-query-token ratio. The
-    whole-string component lets a discriminating suffix break ties between names that share a common
-    token (e.g. ranks `decrease_min` over `decrease_key` for query `decrease_mn`); the token
-    component keeps a query that matches a single token of a compound name (e.g. `priority` vs
-    `decreasePriority`) scoring well.
+    Takes the larger of a whole-string ratio (ignoring underscores) and a token score that
+    averages, over each query token, its best match against the name's tokens. Averaging keeps a
+    short query that matches one token of a long compound name scoring high (recall), while still
+    discriminating names that differ only in a non-shared token so ranking can break ties (e.g.
+    `decrease_min` outranks `decrease_key` for query `decrease_mn`).
     """
     simple = name.rsplit(".", 1)[-1].lower()
     query_squashed = query.lower().replace("_", "").replace(" ", "")
     whole = SequenceMatcher(None, query_squashed, simple.replace("_", "")).ratio()
 
     name_tokens = _normalize_tokens(name)
-    query_tokens = _normalize_tokens(query) or [query_squashed]
-    token_score = 0.0
-    for query_token in query_tokens:
-        best = max(
-            (SequenceMatcher(None, query_token, nt).ratio() for nt in name_tokens), default=0.0
-        )
-        token_score = max(token_score, best)
-    return 0.5 * whole + 0.5 * token_score
+    query_tokens = _normalize_tokens(query)
+    if query_tokens and name_tokens:
+        token_score = sum(
+            max(
+                SequenceMatcher(None, query_token, name_token).ratio() for name_token in name_tokens
+            )
+            for query_token in query_tokens
+        ) / len(query_tokens)
+    else:
+        token_score = 0.0
+    return max(whole, token_score)
 
 
 def _identifier_match(token: str, text: str) -> bool:

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -343,12 +343,9 @@ def _format_results(
     if fuzzy:
         header = f'No exact match for "{query}". Closest declaration(s):'
         note = " (fuzzy match)"
-    elif body_match:
-        header = f'Found {len(declarations)} declaration(s) matching "{query}":'
-        note = " (matched in body)"
     else:
         header = f'Found {len(declarations)} declaration(s) matching "{query}":'
-        note = ""
+        note = " (matched in body)" if body_match else ""
     shown: list[str] = []
     overflow: list[str] = []
     total = len(header)

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -9,6 +9,7 @@ import os
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
+from difflib import SequenceMatcher
 from pathlib import Path
 
 from langchain_core.tools import StructuredTool
@@ -104,6 +105,39 @@ _KEYWORDS_PATTERN = "|".join(
 # non-identifier characters (so "query_aux" won't hit inside "query_auxN" and "insert"
 # won't hit inside "Treap.insert").
 _IDENT_CHAR = r"[0-9A-Za-z_'.]"
+
+
+# Minimum similarity for a fuzzy name suggestion when exact matching finds nothing.
+FUZZY_THRESHOLD = 0.6
+
+
+def _normalize_tokens(name: str) -> list[str]:
+    """Lowercased identifier tokens: drop the namespace qualifier, split on '_' and camelCase."""
+    simple = name.rsplit(".", 1)[-1]
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", simple)
+    return [part.lower() for part in re.split(r"[._\s]+", spaced) if part]
+
+
+def _fuzzy_score(query: str, name: str) -> float:
+    """Similarity in [0, 1] between `query` and a declaration's (final) name.
+
+    Combines a whole-string ratio (ignoring underscores) with the best per-query-token ratio, so a
+    query matching a single token of a compound name (e.g. 'priority' vs 'decreasePriority') still
+    scores well.
+    """
+    simple = name.rsplit(".", 1)[-1].lower()
+    query_squashed = query.lower().replace("_", "").replace(" ", "")
+    whole = SequenceMatcher(None, query_squashed, simple.replace("_", "")).ratio()
+
+    name_tokens = _normalize_tokens(name)
+    query_tokens = _normalize_tokens(query) or [query_squashed]
+    token_score = 0.0
+    for query_token in query_tokens:
+        best = max(
+            (SequenceMatcher(None, query_token, nt).ratio() for nt in name_tokens), default=0.0
+        )
+        token_score = max(token_score, best)
+    return max(whole, token_score)
 
 
 def _identifier_match(token: str, text: str) -> bool:

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -121,9 +121,11 @@ def _normalize_tokens(name: str) -> list[str]:
 def _fuzzy_score(query: str, name: str) -> float:
     """Similarity in [0, 1] between `query` and a declaration's (final) name.
 
-    Combines a whole-string ratio (ignoring underscores) with the best per-query-token ratio, so a
-    query matching a single token of a compound name (e.g. 'priority' vs 'decreasePriority') still
-    scores well.
+    Blends a whole-string ratio (ignoring underscores) with the best per-query-token ratio. The
+    whole-string component lets a discriminating suffix break ties between names that share a common
+    token (e.g. ranks `decrease_min` over `decrease_key` for query `decrease_mn`); the token
+    component keeps a query that matches a single token of a compound name (e.g. `priority` vs
+    `decreasePriority`) scoring well.
     """
     simple = name.rsplit(".", 1)[-1].lower()
     query_squashed = query.lower().replace("_", "").replace(" ", "")
@@ -137,7 +139,7 @@ def _fuzzy_score(query: str, name: str) -> float:
             (SequenceMatcher(None, query_token, nt).ratio() for nt in name_tokens), default=0.0
         )
         token_score = max(token_score, best)
-    return max(whole, token_score)
+    return 0.5 * whole + 0.5 * token_score
 
 
 def _identifier_match(token: str, text: str) -> bool:
@@ -281,6 +283,26 @@ def _body_matching_declarations(content: str, query: str) -> list[tuple[str, str
     return results
 
 
+def _fuzzy_matching_declarations(
+    content: str, query: str, threshold: float = FUZZY_THRESHOLD
+) -> list[tuple[str, str, int, float]]:
+    """`(simple_name, qualified_name, occurrence, score)` for declarations whose name is a close
+    fuzzy match to `query` (score >= threshold). De-duplicated by qualified name, source order.
+    """
+    if not query.strip():
+        return []
+    results: list[tuple[str, str, int, float]] = []
+    seen: set[str] = set()
+    for declaration, qualified, occurrence in _iter_searchable(content):
+        if qualified in seen:
+            continue
+        score = _fuzzy_score(query, qualified)
+        if score >= threshold:
+            seen.add(qualified)
+            results.append((declaration.name, qualified, occurrence, score))
+    return results
+
+
 def _declaration_line(content: str, name: str, occurrence: int = 0) -> int:
     """1-based line number where the declaration of `name` begins (keyword line).
 
@@ -386,6 +408,27 @@ def _collect_matches(
             line = _declaration_line(content, simple_name, occurrence)
             grouped.setdefault((qualified_name, block), []).append((relative_path, line))
     return [(name, block, locations) for (name, block), locations in grouped.items()]
+
+
+def _collect_fuzzy_matches(
+    files: list[tuple[Path, str]], query: str, config: SearchLeanLocalConfig
+) -> list[tuple[str, str, list[tuple[Path, int]]]]:
+    """Group fuzzy matches across files, ranked by descending score, capped to `max_results`."""
+    grouped: dict[tuple[str, str], list[tuple[Path, int]]] = {}
+    scores: dict[str, float] = {}
+    for relative_path, content in files:
+        for simple_name, qualified_name, occurrence, score in _fuzzy_matching_declarations(
+            content, query
+        ):
+            block = extract_function_from_content(content, simple_name, occurrence)
+            if block is None:
+                continue
+            line = _declaration_line(content, simple_name, occurrence)
+            grouped.setdefault((qualified_name, block), []).append((relative_path, line))
+            scores[qualified_name] = max(scores.get(qualified_name, 0.0), score)
+    results = [(name, block, locations) for (name, block), locations in grouped.items()]
+    results.sort(key=lambda result: scores.get(result[0], 0.0), reverse=True)
+    return results[: config.max_results]
 
 
 def _search_root(

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -442,10 +442,14 @@ def _collect_fuzzy_matches(
 def _search_root(
     root: Path, query: str, config: SearchLeanLocalConfig, *, label: str = "LocalLeanSearch"
 ) -> tuple[str, list[tuple[str, str, list[tuple[Path, int]]]]]:
-    """Search `root` by declaration name; fall back to body search only if name finds nothing.
+    """Search by declaration name; if none, fall back to body-identifier search; if still none,
+    fall back to fuzzy name suggestions.
 
-    Returns the formatted text plus the structured declarations it formatted (empty on no match).
-    Walks the tree and reads each file once; the body fallback reuses the cached contents.
+    A body match is an exact-identifier hit and so outranks an approximate fuzzy name match;
+    fuzzy is the last resort before reporting no match. Each tier fires only when the previous
+    one finds nothing, so good exact searches are unaffected. Returns the formatted text plus the
+    structured declarations it formatted (empty on no match). Walks the tree and reads each file
+    once; later tiers reuse the cached contents.
     """
     files = _read_lean_files(root)
     decls = _collect_matches(files, query, body=False)
@@ -456,6 +460,10 @@ def _search_root(
     if body_decls:
         logger.info(f"{label}: Found {len(body_decls)} body matches for '{query}' under {root}")
         return _format_results(query, body_decls, config, body_match=True), body_decls
+    fuzzy_decls = _collect_fuzzy_matches(files, query, config)
+    if fuzzy_decls:
+        logger.info(f"{label}: Found {len(fuzzy_decls)} fuzzy matches for '{query}' under {root}")
+        return _format_results(query, fuzzy_decls, config, fuzzy=True), fuzzy_decls
     logger.info(f"{label}: No results for '{query}'")
     return f'No declarations matching "{query}" found.', []
 
@@ -525,6 +533,7 @@ class LocalLeanSearchInput(BaseModel):
             "Keyword(s) to match against declaration names (case-insensitive). "
             "Multiple words match names containing all of them, e.g. 'Treap insert' "
             "finds `Treap.insert`."
+            " If nothing matches exactly, the closest names are returned as suggestions."
         ),
     )
 
@@ -545,6 +554,7 @@ Mathlib and other dependencies are excluded — use the lean_search tool for tho
 
 Pass a single keyword (e.g. "Treap" or "extract_min"). Multiple words match names
 containing all of them, so "Treap insert" finds `Treap.insert`.
+If no name matches your keyword exactly, the closest declaration names are returned as fuzzy suggestions.
 
 Use this to retrieve project-local definitions you need to reference in a proof,
 e.g. search "Treap" to get the definition of a local `Treap` structure.""",

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -330,6 +330,7 @@ def _format_results(
     declarations: list[tuple[str, str, list[tuple[Path, int]]]],
     config: SearchLeanLocalConfig,
     body_match: bool = False,
+    fuzzy: bool = False,
 ) -> str:
     """Render unique declarations, capping by max_results and max_chars.
 
@@ -339,8 +340,15 @@ def _format_results(
     caps) is listed by name.
     """
     truncation_marker = "\n-- … (truncated; refine your query for the full declaration)"
-    header = f'Found {len(declarations)} declaration(s) matching "{query}":'
-    note = " (matched in body)" if body_match else ""
+    if fuzzy:
+        header = f'No exact match for "{query}". Closest declaration(s):'
+        note = " (fuzzy match)"
+    elif body_match:
+        header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+        note = " (matched in body)"
+    else:
+        header = f'Found {len(declarations)} declaration(s) matching "{query}":'
+        note = ""
     shown: list[str] = []
     overflow: list[str] = []
     total = len(header)

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -14,7 +14,9 @@ from ax_prover.tools.local_lean_search import (
     LocalLeanSearcher,
     SearchLeanLocalConfig,
     _body_matching_declarations,
+    _collect_fuzzy_matches,
     _declaration_line,
+    _fuzzy_matching_declarations,
     _fuzzy_score,
     _identifier_match,
     _iter_lean_files,
@@ -785,3 +787,22 @@ def test_fuzzy_score_low_for_unrelated():
     from ax_prover.tools.local_lean_search import FUZZY_THRESHOLD
 
     assert _fuzzy_score("heapify", "WeightedGraph") < FUZZY_THRESHOLD
+
+
+def test_fuzzy_matching_declarations_finds_close_name():
+    content = "def extract_min : Nat := 0\ndef heapify : Nat := 1\n"
+    matches = _fuzzy_matching_declarations(content, "extractmin")
+    names = [qualified for _simple, qualified, _occ, _score in matches]
+    assert "extract_min" in names
+    assert "heapify" not in names
+
+
+def test_collect_fuzzy_matches_sorts_by_score_and_caps(tmp_path):
+    (tmp_path / "Def.lean").write_text(
+        "def decrease_key : Nat := 0\ndef decrease_min : Nat := 1\ndef unrelated : Nat := 2\n",
+        encoding="utf-8",
+    )
+    files = [(Path("Def.lean"), (tmp_path / "Def.lean").read_text(encoding="utf-8"))]
+    results = _collect_fuzzy_matches(files, "decrease_mn", SearchLeanLocalConfig(max_results=1))
+    assert len(results) == 1  # cap respected
+    assert results[0][0] == "decrease_min"  # closest by score ranked first

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -863,3 +863,13 @@ def test_collect_fuzzy_matches_ranks_closer_suffix_first(tmp_path):
     results = _collect_fuzzy_matches(files, "decrease_mn", SearchLeanLocalConfig(max_results=2))
     names = [name for name, _block, _locs in results]
     assert names == ["decrease_min", "decrease_key"]  # closer suffix ranked first
+
+
+def test_searcher_search_returns_fuzzy_suggestion_on_exact_miss(tmp_path):
+    root = _make_lake_project(tmp_path)
+    (root / "Def.lean").write_text("def extract_min : Nat := 0\n", encoding="utf-8")
+    searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root))
+    # "extractmin" exact-misses (underscore) and isn't a body identifier -> fuzzy fallback fires.
+    result = searcher.search("extractmin")
+    assert "No exact match" in result
+    assert "extract_min" in result

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -16,6 +16,7 @@ from ax_prover.tools.local_lean_search import (
     _body_matching_declarations,
     _collect_fuzzy_matches,
     _declaration_line,
+    _format_results,
     _fuzzy_matching_declarations,
     _fuzzy_score,
     _identifier_match,
@@ -813,6 +814,20 @@ def test_fuzzy_score_preserves_recall_for_single_token_of_long_name():
 
     # A short query that exactly matches one token of a long compound name must stay suggestible.
     assert _fuzzy_score("fold", "Algebra.leftFoldOverMonoidWithIdentity") >= FUZZY_THRESHOLD
+
+
+def test_format_results_fuzzy_header():
+    decls = [("extract_min", "def extract_min := 0", [(Path("Def.lean"), 1)])]
+    out = _format_results("extractmin", decls, SearchLeanLocalConfig(), fuzzy=True)
+    assert "No exact match" in out
+    assert "extractmin" in out
+    assert "fuzzy match" in out
+
+
+def test_format_results_default_header_unchanged():
+    decls = [("foo", "def foo := 0", [(Path("Def.lean"), 1)])]
+    out = _format_results("foo", decls, SearchLeanLocalConfig())
+    assert out.startswith('Found 1 declaration(s) matching "foo":')
 
 
 def test_collect_fuzzy_matches_ranks_closer_suffix_first(tmp_path):

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -831,6 +831,30 @@ def test_format_results_default_header_unchanged():
     assert out.startswith('Found 1 declaration(s) matching "foo":')
 
 
+def test_search_root_exact_match_wins_no_fuzzy(tmp_path):
+    (tmp_path / "Def.lean").write_text("def extract_min : Nat := 0\n", encoding="utf-8")
+    text, decls = _search_root(tmp_path, "extract_min", SearchLeanLocalConfig())
+    assert "No exact match" not in text
+    assert text.startswith('Found 1 declaration(s) matching "extract_min":')
+    assert len(decls) == 1
+
+
+def test_search_root_fuzzy_fires_on_exact_miss(tmp_path):
+    (tmp_path / "Def.lean").write_text("def extract_min : Nat := 0\n", encoding="utf-8")
+    # "extractmin" is NOT a substring of "extract_min" (underscore) -> exact miss -> fuzzy.
+    text, decls = _search_root(tmp_path, "extractmin", SearchLeanLocalConfig())
+    assert "No exact match" in text
+    assert "extract_min" in text
+    assert decls and decls[0][0] == "extract_min"
+
+
+def test_search_root_genuine_miss_returns_empty(tmp_path):
+    (tmp_path / "Def.lean").write_text("def extract_min : Nat := 0\n", encoding="utf-8")
+    text, decls = _search_root(tmp_path, "zzz_no_name_zzz", SearchLeanLocalConfig())
+    assert "No declarations matching" in text
+    assert decls == []
+
+
 def test_collect_fuzzy_matches_ranks_closer_suffix_first(tmp_path):
     (tmp_path / "Def.lean").write_text(
         "def decrease_key : Nat := 0\ndef decrease_min : Nat := 1\n", encoding="utf-8"

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -806,3 +806,20 @@ def test_collect_fuzzy_matches_sorts_by_score_and_caps(tmp_path):
     results = _collect_fuzzy_matches(files, "decrease_mn", SearchLeanLocalConfig(max_results=1))
     assert len(results) == 1  # cap respected
     assert results[0][0] == "decrease_min"  # closest by score ranked first
+
+
+def test_fuzzy_score_preserves_recall_for_single_token_of_long_name():
+    from ax_prover.tools.local_lean_search import FUZZY_THRESHOLD
+
+    # A short query that exactly matches one token of a long compound name must stay suggestible.
+    assert _fuzzy_score("fold", "Algebra.leftFoldOverMonoidWithIdentity") >= FUZZY_THRESHOLD
+
+
+def test_collect_fuzzy_matches_ranks_closer_suffix_first(tmp_path):
+    (tmp_path / "Def.lean").write_text(
+        "def decrease_key : Nat := 0\ndef decrease_min : Nat := 1\n", encoding="utf-8"
+    )
+    files = [(Path("Def.lean"), (tmp_path / "Def.lean").read_text(encoding="utf-8"))]
+    results = _collect_fuzzy_matches(files, "decrease_mn", SearchLeanLocalConfig(max_results=2))
+    names = [name for name, _block, _locs in results]
+    assert names == ["decrease_min", "decrease_key"]  # closer suffix ranked first

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -819,6 +819,7 @@ def test_fuzzy_score_preserves_recall_for_single_token_of_long_name():
 def test_format_results_fuzzy_header():
     decls = [("extract_min", "def extract_min := 0", [(Path("Def.lean"), 1)])]
     out = _format_results("extractmin", decls, SearchLeanLocalConfig(), fuzzy=True)
+    assert out.startswith('No exact match for "extractmin". Closest declaration(s):')
     assert "No exact match" in out
     assert "extractmin" in out
     assert "fuzzy match" in out

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -15,9 +15,11 @@ from ax_prover.tools.local_lean_search import (
     SearchLeanLocalConfig,
     _body_matching_declarations,
     _declaration_line,
+    _fuzzy_score,
     _identifier_match,
     _iter_lean_files,
     _matching_declaration_names,
+    _normalize_tokens,
     _search_root,
     _walk_down_for_roots,
     _walk_up_for_root,
@@ -760,3 +762,26 @@ def test_searcher_records_nothing_on_miss(tmp_path):
     searcher = LocalLeanSearcher(SearchLeanLocalConfig(), base_folder=str(root))
     searcher.search("totally_absent_name")
     assert searcher.returned_declarations == {}
+
+
+def test_normalize_tokens_splits_camel_snake_and_qualifier():
+    assert _normalize_tokens("BinaryHeap.decreaseKey") == ["decrease", "key"]
+    assert _normalize_tokens("extract_min") == ["extract", "min"]
+
+
+def test_fuzzy_score_high_for_near_miss():
+    # Underscore/spelling differences still score high.
+    assert _fuzzy_score("extractmin", "BinaryHeap.extract_min") >= 0.8
+    assert _fuzzy_score("decrese_min", "decrease_min") >= 0.7  # typo
+
+
+def test_fuzzy_score_rewards_single_token_match():
+    # Query matches one token of a compound name.
+    assert _fuzzy_score("priority", "decreasePriority") >= 0.6
+
+
+def test_fuzzy_score_low_for_unrelated():
+    # An unrelated name must score below the suggestion gate, so it is never suggested.
+    from ax_prover.tools.local_lean_search import FUZZY_THRESHOLD
+
+    assert _fuzzy_score("heapify", "WeightedGraph") < FUZZY_THRESHOLD


### PR DESCRIPTION
Adds a fuzzy fallback tier to the local Lean search tool so the agent recovers when it guesses a name that doesn't match exactly (the Dijkstra trace showed it guessing `decrease_priority`/`remove` and getting nothing).

## How it works
Tier order in `_search_root`: **exact name → body-identifier → fuzzy → none**. Fuzzy fires *only* when both exact and body matching miss, so good exact searches are untouched and context isn't bloated (capped by `max_results`).

- `_fuzzy_score(query, name)` = `max(whole-string ratio, mean per-query-token best-match)`. The mean-token component preserves recall for a short query matching one token of a long compound name (`fold`→`leftFoldOver…` = 1.0), while the whole-string component breaks ties (`decrease_min` ranks above `decrease_key` for `decrease_mn`). Unrelated names score below the `FUZZY_THRESHOLD` (0.6) gate.
- `_fuzzy_matching_declarations` / `_collect_fuzzy_matches` mirror the existing exact/body matchers; results are ranked closest-first and capped.
- `_format_results(fuzzy=True)` renders them under `No exact match for "<query>". Closest declaration(s):` with a `(fuzzy match)` marker.

**Tier-order note:** the original spec said exact → fuzzy → body; this was refined (and the spec updated) to exact → body → fuzzy, because a body-identifier match is an *exact* hit (e.g. a `where`-helper) that should outrank an *approximate* fuzzy guess.

## Tests
385 unit tests pass; ruff clean. Coverage: scoring primitives + recall/tie-break/unrelated cases, both matchers (find/exclude, rank+cap, full ordering), the `_format_results` fuzzy header, the `_search_root` tier behavior (exact wins, fuzzy fires on miss, genuine miss empty), and an end-to-end `LocalLeanSearcher.search()` fuzzy test. Pre-existing `query_aux` body-fallback tests pass unchanged; CSLib still unpacks `_search_root` correctly.

Spec: `docs/superpowers/specs/2026-06-08-local-search-caching-and-fuzzy-design.md`
Plan: `docs/superpowers/plans/2026-06-08-ws2-local-search-fuzzy-fallback.md`

Stacks on WS1 (PR #22, already merged into `local-lean-search-tool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is confined to zero-hit searches and is capped; exact and body matches are unchanged, with broad unit coverage on the new tier.
> 
> **Overview**
> Adds a **fuzzy name-matching fallback** to local Lean project search (`search_lean_local`) so near-miss queries (typos, missing underscores, camelCase vs snake_case) still return the closest declarations instead of an empty result.
> 
> **`_search_root` tier order** is now **exact name → body-identifier → fuzzy → none** (spec updated: body exact hits outrank approximate fuzzy guesses). Fuzzy runs only when both prior tiers miss, reusing the same file walk and existing `max_results` / `max_chars` caps.
> 
> Scoring uses `difflib.SequenceMatcher` via `_fuzzy_score` (whole-string + per-token best match, threshold `FUZZY_THRESHOLD` 0.6), with `_collect_fuzzy_matches` ranking by score. Fuzzy hits render under `No exact match for "<query>". Closest declaration(s):` with a `(fuzzy match)` marker; tool and field descriptions document the behavior.
> 
> Unit tests cover scoring, collection/ranking, formatting, tier precedence, and end-to-end `LocalLeanSearcher.search`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd96cc79865e93a962bcee1c2a6e69edba4b2c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->