### PR TITLE
fix: code-review findings in local-search caching + fuzzy

### DIFF
--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -252,6 +252,10 @@ class ProverAgent:
                 bound = getattr(getattr(tool, "func", None), "__self__", None)
                 if isinstance(bound, LocalLeanSearcher):
                     return bound
+                self.logger.warning(
+                    "Local search tool is configured but its searcher instance could not be "
+                    "recovered; used-definition caching is disabled for this run."
+                )
         return None
 
     def _accumulate_used_definitions(self, state: ProverAgentState) -> dict[str, str]:
@@ -265,6 +269,32 @@ class ProverAgent:
             state.last_proposal.code,
             target_name,
         )
+
+    def _render_used_definitions(self, used_definitions: dict[str, str]) -> str | None:
+        """Render the <local-definitions> block, bounded to a fraction of the input budget.
+
+        Whole entries are dropped from the end (verbatim source is never chopped mid-definition) so
+        the cache cannot crowd out the proof state on a token-tight model; at least one entry is
+        always kept, and any drop is noted. Returns None when there is nothing to inject.
+        """
+        if not used_definitions:
+            return None
+        budget = self.max_input_tokens // 4  # chars; an upper bound on the block's token cost
+        kept: list[str] = []
+        total = 0
+        omitted = 0
+        for entry in used_definitions.values():
+            if kept and total + len(entry) > budget:
+                omitted += 1
+                continue
+            kept.append(entry)
+            total += len(entry)
+        definitions = "\n\n".join(kept)
+        if omitted:
+            definitions += (
+                f"\n\n-- ({omitted} more cached definition(s) omitted to fit the context)"
+            )
+        return LOCAL_DEFINITIONS_USER_PROMPT.format(definitions=definitions)
 
     async def _memory_processor_node(self, state: ProverAgentState) -> dict:
         """Process memory using the configured strategy, plus accumulate used local definitions."""
@@ -313,10 +343,8 @@ class ProverAgent:
         if state.experience:
             query = "\n\n".join([query, state.experience])
 
-        if state.used_definitions:
-            definitions_block = LOCAL_DEFINITIONS_USER_PROMPT.format(
-                definitions="\n\n".join(state.used_definitions.values())
-            )
+        definitions_block = self._render_used_definitions(state.used_definitions)
+        if definitions_block:
             query = "\n\n".join([query, definitions_block])
 
         context_messages = [

--- a/src/ax_prover/tools/local_lean_search.py
+++ b/src/ax_prover/tools/local_lean_search.py
@@ -118,21 +118,17 @@ def _normalize_tokens(name: str) -> list[str]:
     return [part.lower() for part in re.split(r"[._\s]+", spaced) if part]
 
 
-def _fuzzy_score(query: str, name: str) -> float:
-    """Similarity in [0, 1] between `query` and a declaration's (final) name.
+def _score_name(query_squashed: str, query_tokens: list[str], name: str) -> float:
+    """Similarity in [0, 1] between a (pre-normalized) query and a declaration's (final) name.
 
-    Takes the larger of a whole-string ratio (ignoring underscores) and a token score that
-    averages, over each query token, its best match against the name's tokens. Averaging keeps a
-    short query that matches one token of a long compound name scoring high (recall), while still
-    discriminating names that differ only in a non-shared token so ranking can break ties (e.g.
-    `decrease_min` outranks `decrease_key` for query `decrease_mn`).
+    `query_squashed` is the lowercased, underscore/space-stripped query; `query_tokens` is its
+    `_normalize_tokens` split. Keeping these as parameters lets a caller normalize the query once
+    and reuse it across every candidate name, rather than recomputing per declaration.
     """
     simple = name.rsplit(".", 1)[-1].lower()
-    query_squashed = query.lower().replace("_", "").replace(" ", "")
     whole = SequenceMatcher(None, query_squashed, simple.replace("_", "")).ratio()
 
     name_tokens = _normalize_tokens(name)
-    query_tokens = _normalize_tokens(query)
     if query_tokens and name_tokens:
         token_score = sum(
             max(
@@ -143,6 +139,20 @@ def _fuzzy_score(query: str, name: str) -> float:
     else:
         token_score = 0.0
     return max(whole, token_score)
+
+
+def _fuzzy_score(query: str, name: str) -> float:
+    """Similarity in [0, 1] between `query` and a declaration's (final) name.
+
+    Takes the larger of a whole-string ratio (ignoring underscores) and a token score that
+    averages, over each query token, its best match against the name's tokens. Averaging keeps a
+    short query that matches one token of a long compound name scoring high (recall), while still
+    discriminating names that differ only in a non-shared token so ranking can break ties (e.g.
+    `decrease_min` outranks `decrease_key` for query `decrease_mn`).
+    """
+    return _score_name(
+        query.lower().replace("_", "").replace(" ", ""), _normalize_tokens(query), name
+    )
 
 
 def _identifier_match(token: str, text: str) -> bool:
@@ -162,6 +172,69 @@ def format_cached_definition_entry(qualified_name: str, block: str, path: Path, 
     return f"-- {qualified_name} — {path}:{line}\n{block}"
 
 
+# Simple names so common in Mathlib/core that a bare (unqualified) occurrence in proof code is far
+# more likely a library reference than the local declaration sharing the name. A returned local
+# declaration whose simple name is one of these is cached only when its FULLY-QUALIFIED name appears
+# in the code, to avoid caching an irrelevant local def that merely collides on a generic name.
+_AMBIGUOUS_BARE_NAMES = frozenset(
+    {
+        "min",
+        "max",
+        "map",
+        "get",
+        "set",
+        "add",
+        "mul",
+        "sub",
+        "div",
+        "mod",
+        "neg",
+        "insert",
+        "erase",
+        "union",
+        "inter",
+        "size",
+        "length",
+        "mem",
+        "comp",
+        "id",
+        "zero",
+        "one",
+        "succ",
+        "pred",
+        "cast",
+        "lift",
+        "join",
+        "bind",
+        "pure",
+        "val",
+        "fst",
+        "snd",
+        "left",
+        "right",
+        "cons",
+        "nil",
+        "head",
+        "tail",
+    }
+)
+
+
+def _used_in_code(qualified_name: str, code: str) -> bool:
+    """Whether a returned declaration is referenced in `code` (precision-aware).
+
+    A fully-qualified reference always counts. A bare simple-name reference counts only when the
+    simple name is distinctive; ubiquitous identifiers (see `_AMBIGUOUS_BARE_NAMES`) require the
+    qualified form, so a local `Foo.min` is not cached just because the proof used Mathlib's `min`.
+    """
+    if _identifier_match(qualified_name, code):
+        return True
+    simple = qualified_name.rsplit(".", 1)[-1]
+    if simple in _AMBIGUOUS_BARE_NAMES:
+        return False
+    return _identifier_match(simple, code)
+
+
 def accumulate_used_definitions(
     cached: dict[str, str],
     returned_declarations: dict[str, tuple[str, Path, int]],
@@ -171,9 +244,10 @@ def accumulate_used_definitions(
     """Append local-search results that `code` actually used to the run-scoped `cached` map.
 
     Append-only and deduped by qualified name. An entry is added only when the local-search tool
-    returned it (it is in `returned_declarations`) AND it is referenced in `code` as a whole
-    identifier. The target theorem's own simple name is excluded. Respects MAX_CACHED_DEFINITIONS
-    and MAX_CACHED_DEFINITION_CHARS; existing entries are never removed.
+    returned it (it is in `returned_declarations`) AND it is referenced in `code` (see `_used_in_code`
+    for the precision-aware match). The target theorem's own simple name is excluded. Respects
+    MAX_CACHED_DEFINITIONS and MAX_CACHED_DEFINITION_CHARS; existing entries are never removed, and an
+    over-budget entry is skipped (not a hard stop) so smaller later definitions can still be cached.
     """
     merged = dict(cached)
     total_chars = sum(len(entry) for entry in merged.values())
@@ -185,11 +259,11 @@ def accumulate_used_definitions(
             break
         if target_simple and qualified_name.rsplit(".", 1)[-1] == target_simple:
             continue
-        if not identifier_in_code(qualified_name, code):
+        if not _used_in_code(qualified_name, code):
             continue
         entry = format_cached_definition_entry(qualified_name, block, path, line)
         if total_chars + len(entry) > MAX_CACHED_DEFINITION_CHARS:
-            break
+            continue
         merged[qualified_name] = entry
         total_chars += len(entry)
     return merged
@@ -294,12 +368,15 @@ def _fuzzy_matching_declarations(
     """
     if not query.strip():
         return []
+    # Normalize the query once and reuse it across every candidate name.
+    query_squashed = query.lower().replace("_", "").replace(" ", "")
+    query_tokens = _normalize_tokens(query)
     results: list[tuple[str, str, int, float]] = []
     seen: set[str] = set()
     for declaration, qualified, occurrence in _iter_searchable(content):
         if qualified in seen:
             continue
-        score = _fuzzy_score(query, qualified)
+        score = _score_name(query_squashed, query_tokens, qualified)
         if score >= threshold:
             seen.add(qualified)
             results.append((declaration.name, qualified, occurrence, score))

--- a/tests/unit/prover/test_used_definition_caching.py
+++ b/tests/unit/prover/test_used_definition_caching.py
@@ -95,5 +95,36 @@ def test_proposer_node_injects_local_definitions():
     from ax_prover.prover.agent import ProverAgent
 
     source = inspect.getsource(ProverAgent._proposer_node)
+    assert "_render_used_definitions" in source
     assert "state.used_definitions" in source
-    assert "LOCAL_DEFINITIONS_USER_PROMPT" in source
+
+
+def test_render_used_definitions_drops_trailing_entries_over_budget():
+    from ax_prover.prover.agent import ProverAgent
+
+    fake = SimpleNamespace(max_input_tokens=400)  # budget = 100 chars
+    render = ProverAgent._render_used_definitions.__get__(fake)
+    used = {"A.one": "x" * 60, "A.two": "y" * 60, "A.three": "z" * 60}
+    block = render(used)
+    assert "x" * 60 in block  # first entry kept
+    assert "y" * 60 not in block  # over budget -> dropped
+    assert "omitted to fit" in block  # drop is noted
+
+
+def test_render_used_definitions_keeps_all_when_budget_ample():
+    from ax_prover.prover.agent import ProverAgent
+
+    fake = SimpleNamespace(max_input_tokens=1_000_000)
+    render = ProverAgent._render_used_definitions.__get__(fake)
+    block = render({"A.one": "def one := 1", "A.two": "def two := 2"})
+    assert "def one := 1" in block
+    assert "def two := 2" in block
+    assert "omitted" not in block
+
+
+def test_render_used_definitions_empty_returns_none():
+    from ax_prover.prover.agent import ProverAgent
+
+    fake = SimpleNamespace(max_input_tokens=1000)
+    render = ProverAgent._render_used_definitions.__get__(fake)
+    assert render({}) is None

--- a/tests/unit/tools/test_local_lean_search.py
+++ b/tests/unit/tools/test_local_lean_search.py
@@ -873,3 +873,46 @@ def test_searcher_search_returns_fuzzy_suggestion_on_exact_miss(tmp_path):
     result = searcher.search("extractmin")
     assert "No exact match" in result
     assert "extract_min" in result
+
+
+def test_accumulate_skips_oversized_entry_but_keeps_later_small_ones():
+    """An over-budget entry is skipped, not a hard stop: smaller later defs still get cached."""
+    from ax_prover.tools.local_lean_search import MAX_CACHED_DEFINITION_CHARS
+
+    big = "x" * (MAX_CACHED_DEFINITION_CHARS - 1100)  # its entry fits, leaving ~1100 chars
+    huge = "y" * 1400  # entry would overflow the remaining budget -> skipped
+    pool = {
+        "N.a_big": (big, Path("D.lean"), 1),
+        "N.b_huge": (huge, Path("D.lean"), 2),
+        "N.c_small": ("def c := 1", Path("D.lean"), 3),
+    }
+    code = "a_big b_huge c_small"
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert "N.a_big" in result
+    assert "N.b_huge" not in result  # over budget -> skipped
+    assert "N.c_small" in result  # small, still cached after the skip (continue, not break)
+
+
+def test_accumulate_skips_ambiguous_bare_name_used_as_library_ref():
+    """A local decl with a ubiquitous simple name (min) is cached only on an explicit qualified
+    reference, not on a bare reference that is really a Mathlib/core use."""
+    pool = {"Foo.min": ("def min : Nat := 0", Path("D.lean"), 1)}
+    code = "theorem t : a ≤ min a b := by exact min_le_left a b"  # bare 'min' = library
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert result == {}
+
+
+def test_accumulate_caches_ambiguous_name_when_qualified_reference_present():
+    pool = {"Foo.min": ("def min : Nat := 0", Path("D.lean"), 1)}
+    code = "theorem t : True := by exact Foo.min"
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert "Foo.min" in result
+
+
+def test_accumulate_caches_distinctive_namespaced_name_via_bare_ref():
+    """Recall preserved: a distinctive simple name (extract_min) is cached from a bare reference
+    (the agent writes it unqualified after `open`)."""
+    pool = {"BinaryHeap.extract_min": ("def extract_min : Nat := 0", Path("D.lean"), 1)}
+    code = "theorem t : True := by exact extract_min h"
+    result = accumulate_used_definitions({}, pool, code, target_name="t")
+    assert "BinaryHeap.extract_min" in result


### PR DESCRIPTION
Addresses the high-effort code review of the WS1+WS2 local-search work. Fixes the three substantive findings plus two cheap ones; the rest were lower-severity (and the reported `str.format` brace crash was refuted — `str.format` does not re-scan replacement values).

- **#1 char-cap `break`→`continue`** (`accumulate_used_definitions`): an over-budget definition no longer aborts the loop, so smaller later definitions the proof used still get cached.
- **#2 ambiguous bare-name precision** (`_used_in_code` + `_AMBIGUOUS_BARE_NAMES`): a local decl with a ubiquitous simple name (`min`/`map`/`insert`/…) is cached only when its *qualified* name appears in the code — avoids caching `Foo.min` just because the proof used Mathlib's `min`. Distinctive names (e.g. `extract_min`) still cache from a bare reference, preserving recall for `open`ed names.
- **#4 budget the injected block** (`_render_used_definitions`): the `<local-definitions>` block is bounded to a fraction of the model's input window, dropping whole trailing entries (verbatim Lean source is never chopped) with an omission note — consistent with the existing build-output truncation.
- **#7 silent no-op log** (`_find_local_searcher`): warns when the local-search tool is configured but its searcher can't be recovered, so the caching feature degrading to a no-op is visible.
- **#8 hoist query normalization** (`_score_name`): the fuzzy query is normalized once per search instead of once per declaration.

392 unit tests pass (7 new), ruff clean. New tests cover the continue-not-break cap, the ambiguous-vs-qualified-vs-distinctive caching cases, and the injection budget (drop-trailing / keep-all / empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what definitions are cached and how much context the proposer sees each iteration; behavior is intentional but can affect proof quality on name collisions or large caches.
> 
> **Overview**
> Hardens **local-search used-definition caching** and how those definitions are fed back into the proposer.
> 
> **Caching (`accumulate_used_definitions`)** now uses **`_used_in_code`** instead of bare identifier matching: ubiquitous simple names (`min`, `map`, `insert`, …) are cached only when the **qualified** name appears in the proof, while distinctive names still match bare references. When the char budget is exceeded, an oversized entry is **skipped** (`continue`) rather than stopping the loop, so later smaller defs can still be added.
> 
> **Proposer prompt**: **`_render_used_definitions`** caps the `<local-definitions>` block to roughly **¼ of `max_input_tokens`** (char proxy), dropping **whole trailing entries** with an omission note instead of dumping the full cache.
> 
> **Ops / perf**: **`_find_local_searcher`** logs a warning if the local-search tool is configured but the `LocalLeanSearcher` instance cannot be recovered. Fuzzy search **normalizes the query once** per file scan via **`_score_name`**.
> 
> Unit tests cover budget rendering, continue-on-oversize, and ambiguous vs qualified caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95413bedf55c1f5be2df879ae6a5b64be98ae14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->