### PR TITLE
Change build command to use UV

### DIFF
--- a/gcp/scripts/build_runner.sh
+++ b/gcp/scripts/build_runner.sh
@@ -24,7 +24,7 @@ BASE_IMAGE="${AR_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPO}/${BASE_IMAG
 # Build wheel locally (setuptools-scm uses git to determine version)
 echo "==> Building wheel"
 rm -rf dist/
-python3 -m build --wheel
+uv build --wheel
 echo "==> Built: $(ls dist/*.whl)"
 
 gcloud config set project "${GCP_PROJECT_ID}" >/dev/null


### PR DESCRIPTION
Currently, our GCP commands to build a new runner call python directly. However, I believe most of the developers working on this project use UV. Therefore, I am changing it to use `uv build` and spare ourselves some local file editing when running experiments. 

Closes AxiomaticX/ax-agent#726

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to the local wheel build command in a dev/CI script; no runtime or security impact.
> 
> **Overview**
> The GCP runner build script now builds the local wheel with **`uv build --wheel`** instead of **`python3 -m build --wheel`**, aligning **`build_runner.sh`** with how other GCP scripts (e.g. **`test_local.sh`**) already build wheels.
> 
> Wheel output still goes to **`dist/`** for the same Cloud Build submit flow; only the local packaging command changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26673fc0a66021042f8bbe5e05d4899ee13c1110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->