### PR TITLE
Remove memory limit for lean interact

### DIFF
--- a/src/ax_prover/config.py
+++ b/src/ax_prover/config.py
@@ -108,6 +108,7 @@ class LeanInteractConfig:
     Uses lean_interact's default configuration values.
     """
 
+    max_total_memory: float = 1.0
     verbose: bool = False
 
 

--- a/src/ax_prover/utils/lean_interact.py
+++ b/src/ax_prover/utils/lean_interact.py
@@ -49,7 +49,7 @@ class LeanInteractServer:
                     project=project,
                     verbose=self._config.verbose,
                 )
-                self._server = AutoLeanServer(repl_config)
+                self._server = AutoLeanServer(repl_config, max_total_memory=1.0)
                 logger.debug(f"Created LeanInteract server for {self._base_folder}")
 
         return self._server

--- a/src/ax_prover/utils/lean_interact.py
+++ b/src/ax_prover/utils/lean_interact.py
@@ -49,7 +49,9 @@ class LeanInteractServer:
                     project=project,
                     verbose=self._config.verbose,
                 )
-                self._server = AutoLeanServer(repl_config, max_total_memory=1.0)
+                self._server = AutoLeanServer(
+                    repl_config, max_total_memory=self._config.max_total_memory
+                )
                 logger.debug(f"Created LeanInteract server for {self._base_folder}")
 
         return self._server


### PR DESCRIPTION
Lean interact was crashing randomly due to memory limitations in the local environments. I have managed to mitigate the problem by removing the memory limit of the `AutoLeanServer` by default. I've added the parameter to the `LeanInteractConfig` in case someone would like to restrain the maximum memory a every Lean server can take. 

Closes AxiomaticX/ax-agent#727

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small runtime-tuning change for Lean REPL memory; default increases resource use locally but does not touch auth, data, or core proof logic.
> 
> **Overview**
> Addresses random **LeanInteract** crashes in local runs by passing **`max_total_memory`** into **`AutoLeanServer`** when the goal-state server is created in `lean_interact.py`.
> 
> Adds **`max_total_memory`** (default **`1.0`**, described in the PR as lifting the prior cap) on **`LeanInteractConfig`** under **`RuntimeConfig.lean_interact`**, so deployments can tighten the cap via config/OmegaConf without code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2428a7b046ccf4bdf2876c46191f86bc515fcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->