### PR TITLE
Add GPT-5.6 Sol support

### DIFF
--- a/src/ax_prover/configs/llms.yaml
+++ b/src/ax_prover/configs/llms.yaml
@@ -66,6 +66,30 @@ llm_configs:
       thinking_level: "high"
 
   # OpenAI models
+  gpt_5_6_sol:
+    # gpt-5.6-sol is the flagship of the GPT-5.6 family (the `gpt-5.6` alias
+    # routes here). effort supports none/low/medium/high/xhigh/max.
+    # effort=medium keeps proposal latency reasonable; effort=high can produce
+    # multi-minute reasoning traces per call. An explicit timeout is set because
+    # the OpenAI client otherwise waits forever (request_timeout defaults to None),
+    # so a stalled request would hang the whole run.
+    model: "openai:gpt-5.6-sol"
+    provider_config:
+      temperature: null
+      max_tokens: null
+      timeout: 600
+      reasoning:
+        effort: "high"
+        # summary: "auto"  # We don't support summaries yet because we are not verified
+    retry_config:
+      stop_after_attempt: 6
+      wait_exponential_jitter: true
+      exponential_jitter_params:
+        initial: 0.5
+        max: 30
+        exp_base: 2.0
+        jitter: 1.0
+
   gpt_5_2:
     model: "openai:gpt-5.2"
     provider_config:

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -94,7 +94,9 @@ class ProverAgent:
         summary_llm_config = self.config.summarize_output.llm or self.config.prover_llm
         self.summary_llm_client = LLMClient(summary_llm_config)
 
-        self.max_input_tokens = self.llm_client.profile.get("max_input_tokens")
+        # Fall back to a conservative default when the model profile is unknown
+        # (e.g. models newer than the installed langchain profile registry).
+        self.max_input_tokens = self.llm_client.profile.get("max_input_tokens") or 200000
         if self.max_input_tokens < 1000:
             self.logger.error("Error: max_input_tokens abnormally small")
 

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -37,6 +37,21 @@ def create_llm(config: LLMConfig) -> BaseChatModel:
     )
 
 
+def _sanitize_replayed_tool_calls(message: AIMessage) -> None:
+    """Strip ``parsed_arguments`` from OpenAI ``function_call`` content blocks in place.
+
+    The structured-output (`.parse()`) path adds a ``parsed_arguments`` field to each
+    function-call block. When such an assistant message is replayed in a later request,
+    the OpenAI Responses API rejects it ("Unknown parameter: input[..].parsed_arguments").
+    Removing it keeps tool-calling + structured-output loops working.
+    """
+    if not isinstance(message.content, list):
+        return
+    for block in message.content:
+        if isinstance(block, dict) and block.get("type") == "function_call":
+            block.pop("parsed_arguments", None)
+
+
 async def agentic_loop(
     client: "LLMClient",
     messages: list[BaseMessage],
@@ -51,6 +66,7 @@ async def agentic_loop(
         intermediate AI message, tool result, and the final response.
     """
     response = await client.ainvoke(messages, tools=tools, output_schema=output_schema)
+    _sanitize_replayed_tool_calls(response)
     new_messages: list[BaseMessage] = [response]
 
     tool_node = ToolNode(tools)
@@ -75,6 +91,7 @@ async def agentic_loop(
             response = await client.ainvoke(
                 invoke_messages, tools=tools, output_schema=output_schema
             )
+        _sanitize_replayed_tool_calls(response)
 
         new_messages.append(response)
 


### PR DESCRIPTION
Adding functionality for GPT-5.6 Sol

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared LLM agentic loop and prover token limits used on every proposal; fixes are targeted but affect all OpenAI tool+schema flows.
> 
> **Overview**
> Adds a reusable **`gpt_5_6_sol`** entry in `llms.yaml` for `openai:gpt-5.6-sol` with **high** reasoning effort, a **600s** request timeout, and a **6-attempt** exponential-jitter retry policy suited to long reasoning runs.
> 
> **ProverAgent** now defaults **`max_input_tokens`** to **200,000** when the LangChain model profile omits it (e.g. newer models), so context truncation logic still behaves safely.
> 
> The **agentic tool loop** strips **`parsed_arguments`** from OpenAI `function_call` content blocks before messages are replayed, fixing Responses API rejections when combining **structured output** with **tool calling**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f676040d428032bf89c93d34f884313dbc5fdc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->