### PR TITLE
fix: serialize Lean REPL access and pinpoint search-tactic feedback

### DIFF
--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -568,10 +568,13 @@ async def _detect_cheats_in_code(
     if proposed_declaration.kind == "axiom":
         return AxiomDetectedFeedback(count=1, locations=proposed_declaration.code)
 
-    if proposed_declaration.search_tactics:
-        return SearchTacticsDetectedFeedback(
-            count=len(proposed_declaration.search_tactics), locations=proposed_declaration.code
+    if search_tactics := proposed_declaration.search_tactics:
+        # Pinpoint the offending tactics by line so the prover replaces exactly those,
+        # instead of dumping the whole proof and letting it strip out innocent tactics.
+        locations = "\n".join(
+            f"line {tactic.start_pos.line}: {tactic.tactic.strip()}" for tactic in search_tactics
         )
+        return SearchTacticsDetectedFeedback(count=len(search_tactics), locations=locations)
     return None
 
 

--- a/src/ax_prover/utils/lean_interact.py
+++ b/src/ax_prover/utils/lean_interact.py
@@ -24,11 +24,18 @@ class LeanInteractServer:
         self._config = config
         self._server: AutoLeanServer | None = None
         self._lock = asyncio.Lock()  # lock to ensure only one server is created
+        self._run_lock = asyncio.Lock()  # serialize commands: the REPL is one subprocess
 
     async def run(self, command: Command) -> CommandResponse | LeanError:
-        "Run the command and return the response or error."
+        """Run the command and return the response or error.
+
+        Commands are serialized: the REPL is a single subprocess, and concurrent
+        callers (experiment samples share one server) would otherwise race on it or
+        trip its memory backstop, surfacing as spurious LeanErrors.
+        """
         server = await self._get_server()
-        return await server.async_run(command)
+        async with self._run_lock:
+            return await server.async_run(command)
 
     async def aclose(self) -> None:
         "Close the server."

--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from lean_interact import Command, FileCommand
-from lean_interact.interface import DeclarationInfo, Sorry, Tactic
+from lean_interact.interface import CommandResponse, DeclarationInfo, LeanError, Sorry, Tactic
 
 from ..models.declaration import Declaration
 from .lean_interact import LeanInteractServer
@@ -92,15 +92,15 @@ def format_goal_state_at_sorries(sorries: list[Sorry]) -> str:
 
 async def list_declarations_from_code(
     server: LeanInteractServer, code: str, all_tactics: bool = False
-) -> list[DeclarationInfo]:
+) -> list[Declaration]:
     """List all declarations from a code snippet."""
     response = await server.run(Command(cmd=code, declarations=True, all_tactics=all_tactics))
-    return _bundle_declarations(response.declarations, response.sorries, response.tactics)
+    return _bundle_response(response, "the provided code snippet")
 
 
 async def list_declarations_from_file(
     server: LeanInteractServer, file_path: Path, all_tactics: bool = False
-) -> list[DeclarationInfo]:
+) -> list[Declaration]:
     """List all declarations from a file.
 
     Set `all_tactics=True` to also collect the tactics used in each declaration (needed for
@@ -110,6 +110,18 @@ async def list_declarations_from_file(
     response = await server.run(
         FileCommand(path=str(file_path), declarations=True, all_tactics=all_tactics)
     )
+    return _bundle_response(response, str(file_path))
+
+
+def _bundle_response(response: CommandResponse | LeanError, source: str) -> list[Declaration]:
+    """Turn a REPL response into declarations, failing loudly on a fatal Lean error.
+
+    A file that does not compile at all (e.g. a missing import) comes back as a `LeanError`,
+    which carries no declarations. Surfacing its message here turns an opaque downstream
+    `AttributeError` into a clear compilation failure the caller can report.
+    """
+    if isinstance(response, LeanError):
+        raise RuntimeError(f"Lean failed to process {source}:\n{response.message}")
     return _bundle_declarations(response.declarations, response.sorries, response.tactics)
 
 

--- a/tests/unit/prover/test_cheat_detection.py
+++ b/tests/unit/prover/test_cheat_detection.py
@@ -1,0 +1,50 @@
+"""Tests for the reviewer's cheat detection (agent._detect_cheats_in_code)."""
+
+from types import SimpleNamespace
+
+from lean_interact.interface import Tactic
+
+from ax_prover.models.declaration import Declaration
+from ax_prover.models.messages import SearchTacticsDetectedFeedback
+from ax_prover.prover.agent import _detect_cheats_in_code
+
+
+def _make_tactic(line: int, tactic: str) -> Tactic:
+    return Tactic(
+        pos={"line": line, "column": 0},
+        endPos={"line": line, "column": len(tactic)},
+        goals="",
+        tactic=tactic,
+    )
+
+
+def _make_declaration(tactics: list[Tactic], *, kind: str = "theorem") -> Declaration:
+    """Declaration carrying only what cheat detection reads (info.kind, tactics)."""
+    return Declaration.model_construct(info=SimpleNamespace(kind=kind), tactics=tactics)
+
+
+class TestSearchTacticsFeedback:
+    """The search-tactics rejection must pinpoint the offending tactics."""
+
+    async def test_reports_each_offending_tactic_by_line(self):
+        proposed = _make_declaration(
+            [
+                _make_tactic(line=42, tactic="simp?"),
+                _make_tactic(line=50, tactic="exact? using h"),
+            ]
+        )
+
+        feedback = await _detect_cheats_in_code(proposed, [], [])
+
+        assert isinstance(feedback, SearchTacticsDetectedFeedback)
+        assert feedback.count == 2
+        assert "line 42: simp?" in feedback.locations
+        assert "line 50: exact? using h" in feedback.locations
+
+    async def test_does_not_flag_innocent_tactics(self):
+        """field_simp and bare apply are ordinary tactics, not search tactics."""
+        proposed = _make_declaration(
+            [_make_tactic(line=1, tactic="field_simp"), _make_tactic(line=2, tactic="apply foo")]
+        )
+
+        assert await _detect_cheats_in_code(proposed, [], []) is None

--- a/tests/unit/utils/test_lean_interact.py
+++ b/tests/unit/utils/test_lean_interact.py
@@ -6,6 +6,7 @@ class wires `run()` to the underlying server. End-to-end behavior against a real
 Lean project is covered in tests/regression.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from lean_interact import Command
@@ -46,3 +47,32 @@ class TestLeanInteractServer:
         assert result == dummy_result
         fake_server.async_run.assert_awaited_once()
         fake_server.kill.assert_called_once()
+
+    async def test_run_serializes_concurrent_commands(self, tmp_path, monkeypatch):
+        """Concurrent run() calls never overlap on the single-subprocess REPL."""
+        active = 0
+        max_active = 0
+
+        async def fake_async_run(_command):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0)  # yield: overlap would surface here if unlocked
+            active -= 1
+            return "ok"
+
+        fake_server = MagicMock()
+        fake_server.async_run = AsyncMock(side_effect=fake_async_run)
+
+        monkeypatch.setattr(
+            "ax_prover.utils.lean_interact.AutoLeanServer", lambda *_a, **_k: fake_server
+        )
+        monkeypatch.setattr("ax_prover.utils.lean_interact.LocalProject", lambda **_k: None)
+        monkeypatch.setattr("ax_prover.utils.lean_interact.LeanREPLConfig", lambda **_k: None)
+
+        async with LeanInteractServer(str(tmp_path), LeanInteractConfig()) as server:
+            await asyncio.gather(
+                *(server.run(Command(cmd="example : 1 = 1 := rfl")) for _ in range(10))
+            )
+
+        assert max_active == 1

--- a/tests/unit/utils/test_lean_parsing.py
+++ b/tests/unit/utils/test_lean_parsing.py
@@ -7,6 +7,7 @@ from lean_interact.interface import (
     DeclarationInfo,
     DeclModifiers,
     DeclSignature,
+    LeanError,
     Pos,
     Range,
     ScopeInfo,
@@ -184,6 +185,16 @@ class TestListDeclarationsFromCode:
             for info, sorries, tactics in scenarios
         ]
         assert result == expected
+
+    async def test_raises_clear_error_on_fatal_lean_error(self):
+        """A fatal LeanError (e.g. a file that does not compile) surfaces its message
+        instead of failing later with an opaque AttributeError on `.declarations`."""
+        server = MagicMock(
+            run=AsyncMock(return_value=LeanError(message="unknown package 'Mathlib'"))
+        )
+
+        with pytest.raises(RuntimeError, match="unknown package 'Mathlib'"):
+            await list_declarations_from_code(server, "import Mathlib")
 
 
 class TestFormatGoalStateAtSorries:


### PR DESCRIPTION
## Summary

Two experiment-robustness fixes split out of #35 so they can be reviewed and merged
independently. Both surfaced during larger-scale experiment runs and are model-agnostic
(nothing DeepSeek-specific).

### Serialize LeanInteract REPL access with a per-command lock
The single `AutoLeanServer` subprocess is shared by all concurrent experiment samples, but
`run()` only locked server *creation*, not command *execution*. Firing many full-Mathlib
`FileCommand`s at one REPL at once races the subprocess and trips its memory backstop,
surfacing as spurious `LeanError`s (the 0-iteration startup crashes). A per-command run
lock serializes execution; lake builds are unaffected (separate subprocesses).

### Pinpoint search-tactic feedback and surface fatal Lean errors
- `SearchTacticsDetectedFeedback` dumped the entire declaration as its "Locations", so the
  prover could not tell which tactic was flagged and stripped innocent tactics
  (`field_simp`, `apply`) out of a compiling proof. Each offending tactic is now reported
  with its line number. The detection regex itself is unchanged.
- A file that fails to compile comes back from `lean_interact` as a `LeanError` (message
  only, no declarations), so `list_declarations_from_*` blew up with an opaque
  `AttributeError` on `.declarations`. It now detects `LeanError` and raises the actual
  Lean compile message.

## Tests
Adds/keeps coverage: `test_lean_interact.py` (lock serializes concurrent commands),
`test_cheat_detection.py` (per-line tactic reporting, innocent tactics not flagged),
`test_lean_parsing.py` (fatal `LeanError` → clear `RuntimeError`). Full unit suite green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Serializing all LeanInteract commands can increase latency under heavy parallelism, but it fixes correctness of shared REPL use; parsing and feedback changes are localized with new unit tests.
> 
> **Overview**
> Hardens concurrent experiment runs and prover feedback when Lean parsing or cheat detection fails.
> 
> **LeanInteract** now holds a per-command `asyncio` lock so only one REPL command runs at a time on the shared subprocess, avoiding races and spurious `LeanError`s when many samples hit the same server.
> 
> **Search-tactic rejection** no longer puts the full declaration in `SearchTacticsDetectedFeedback.locations`; it lists each flagged tactic as `line N: <tactic>` so the prover can fix only `simp?` / `exact?`-style lines instead of rewriting the whole proof.
> 
> **Declaration listing** routes REPL results through `_bundle_response`, which raises `RuntimeError` with Lean’s message when the response is a fatal `LeanError` (e.g. bad import) instead of failing on missing `.declarations`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22fa70907135fe23bf62abba4f8bd221d720d553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->