### PR TITLE
Restore get_unproven for ax-prover-server sorry detection

### DIFF
--- a/src/ax_prover/utils/lean_parsing.py
+++ b/src/ax_prover/utils/lean_parsing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 from lean_interact import Command, FileCommand
@@ -12,6 +13,29 @@ from .lean_interact import LeanInteractServer
 from .logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def get_unproven(folder: str, file_path: str) -> list[str]:
+    """Return the names of declarations in a file that still contain `sorry`.
+
+    Synchronous, self-contained entry point for external callers (e.g. the
+    ax-prover-server sorry-detection script): it owns the LeanInteractServer
+    lifecycle and delegates the parsing to `parse_prove_target`, so the
+    detection logic lives in exactly one place.
+
+    Must be called from a synchronous context (no running event loop).
+    """
+
+    async def _run() -> list[str]:
+        # Imported lazily to avoid a circular import (proving imports this module).
+        from ..config import LeanInteractConfig
+        from .proving import parse_prove_target
+
+        async with LeanInteractServer(folder, LeanInteractConfig()) as server:
+            items = await parse_prove_target(server, folder, file_path)
+            return [item.location.name for item in items]
+
+    return asyncio.run(_run())
 
 
 def read_declaration_source_code(declaration: Declaration, file_path: Path) -> str:

--- a/tests/unit/test_server_contract.py
+++ b/tests/unit/test_server_contract.py
@@ -1,0 +1,37 @@
+"""Guards the surface ax-prover-server depends on from ax-prover-base.
+
+ax-prover-server consumes ax-prover-base as an external tool, so refactors here can silently
+break the bot with no signal in this repo (it happened once, in #28, which removed
+`get_unproven`). This module is the single place that enumerates each dependency the server
+relies on. Each test names the exact server usage site so the contract is auditable from here.
+
+These tests assert only that ax-prover-base still *exposes* the contract; they cannot verify
+the server still calls it correctly. A true end-to-end check belongs in ax-prover-server.
+"""
+
+import inspect
+from pathlib import Path
+
+import ax_prover
+from ax_prover.utils.lean_parsing import get_unproven
+
+
+def test_get_unproven_is_sync_two_arg_callable():
+    """Sorry detection imports get_unproven and calls it as get_unproven(folder, file_path).
+
+    Server usage: src/ax_prover_server/scripts/detect_unproven.sh.template
+        from ax_prover.utils.lean_parsing import get_unproven
+        get_unproven(".", "<lean_file>")
+    """
+    assert not inspect.iscoroutinefunction(get_unproven)
+    assert list(inspect.signature(get_unproven).parameters) == ["folder", "file_path"]
+
+
+def test_default_config_ships_with_package():
+    """Prover jobs run `ax-prover --config configs/default.yaml prove ...`, so the bundled
+    default config must exist inside the installed package.
+
+    Server usage: src/ax_prover_server/scripts/run_prover.sh.template
+    """
+    default_config = Path(ax_prover.__file__).parent / "configs" / "default.yaml"
+    assert default_config.is_file()


### PR DESCRIPTION
Notes: 

The ax-prover-server repo [here](https://github.com/AxiomaticX/ax-prover-server/blob/cb27ebf238bde5437d0e021418294ed09a1a6f16/src/ax_prover_server/scripts/detect_unproven.sh.template#L17-L21) imports the function `get_unproven` from ax-prover-base. 

This function was accidentally removed in [PR 28]( https://github.com/Axiomatic-AI/ax-prover-base/pull/28) to ax-prover-base, breaking imports upstream. Adding this functionality back so the detection logic stays in one place, plus a guard test locking the external import path and signature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 45eee6ffc84282d8c62185d42caad6860d1d42b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->