### PR TITLE
Fix CI ruff failure: pin ruff version and reformat CLAUDE.md

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4
         with:
           version-file: "uv.lock"
           args: "format --check --diff"
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4
         with:
           version-file: "uv.lock"
           args: "check"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v4.1.0
         with:
           version-file: "uv.lock"
           args: "format --check --diff"
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v4.1.0
         with:
           version-file: "uv.lock"
           args: "check"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
         with:
+          version-file: "uv.lock"
           args: "format --check --diff"
 
   ruff-check:
@@ -21,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
+          version-file: "uv.lock"
           args: "check"
 
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,9 @@ def _format_relative_time(timestamp_str: str) -> str:
 
 Good (complex function with unintuitive logic, multi-line docstring justified):
 ```python
-def _assign_hierarchical_numbers(checkpoints: list[dict], parent_map: dict[str, str | None]) -> None:
+def _assign_hierarchical_numbers(
+    checkpoints: list[dict], parent_map: dict[str, str | None]
+) -> None:
     """
     Assign hierarchical numbers to checkpoints, detecting branches from restorations.
 


### PR DESCRIPTION
- CI on `main` broke after merging #39 because `astral-sh/ruff-action@v3` installs the **latest** ruff when no version is pinned. Ruff 0.16.0 was released between the PR's checks passing (07-22, ruff 0.15.x) and the merge (07-24), and it newly formats Python code blocks inside markdown files — flagging a long signature in `CLAUDE.md`.
- Pin the CI ruff version to `uv.lock` (currently 0.15.0) so CI matches the locked dev dependency and unpinned upstream releases can't break `main` again.
- Wrap the offending signature in `CLAUDE.md` so it's also clean under ruff ≥0.16.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and documentation-only changes; no application runtime or security-sensitive code paths are modified.
> 
> **Overview**
> **CI** no longer installs the latest Ruff on every run. Both `ruff-format` and `ruff-check` jobs use `astral-sh/ruff-action@v4.1.0` with `version-file: "uv.lock"`, so the linter/formatter version matches the locked dev dependency (currently **0.15.0**) instead of floating with upstream releases.
> 
> **Docs example** in `CLAUDE.md` splits the `_assign_hierarchical_numbers(...)` signature across lines so it satisfies stricter markdown/Python-block formatting in newer Ruff (e.g. 0.16+), avoiding failures when CI or contributors run a newer formatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e6a6f23f46a40f6e78045b08f7a65767ae0951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->