### PR TITLE
Codex/entropy tracing v4

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -15,6 +15,9 @@ prover:
   summarize_output:
     enabled: true
     llm: ${prover.prover_llm}
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: false
 runtime:
   max_tool_calling_iterations: 1
   lean:

--- a/configs/kimina_reasoning_trace.yaml
+++ b/configs/kimina_reasoning_trace.yaml
@@ -1,0 +1,48 @@
+prover:
+  prover_llm:
+    model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 0.6
+      top_p: 0.95
+      seed: 42
+      max_tokens: 8096
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        include_reasoning: true
+    retry_config:
+      stop_after_attempt: 1
+  proposer_tools: {}
+  max_iterations: 6
+  memory_config:
+    class_name: MemorylessProcessor
+    init_args: {}
+  summarize_output:
+    enabled: false
+  reviewer_enabled: false
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 151936
+    require_alignment: true
+    entropy_version: reasoning_topk_v1
+  user_comments: >-
+    Use only the imports already present in the file. Return the complete target
+    theorem with a proof and do not add axioms, constants, sorry, or admit.
+
+runtime:
+  max_tool_calling_iterations: 1
+  lean:
+    cache_get_timeout: 600
+    build_timeout: 1200
+    check_file_timeout: 300
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/configs/paper_kimina_entropy.yaml
+++ b/configs/paper_kimina_entropy.yaml
@@ -1,0 +1,34 @@
+prover:
+  prover_llm:
+    model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 0.6
+      top_p: 0.95
+      max_tokens: 24576
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        include_reasoning: true
+    retry_config:
+      stop_after_attempt: 3
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 151936
+    # Tracing must remain observational. Unaligned calls are persisted and
+    # rejected by the post-run smoke/full artifact gate, never fed back to or
+    # used to terminate the AxProver agent.
+    require_alignment: false
+    entropy_version: reasoning_topk_v1
+runtime:
+  lean:
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/configs/paper_kimina_entropy_v3.yaml
+++ b/configs/paper_kimina_entropy_v3.yaml
@@ -1,0 +1,52 @@
+prover:
+  prover_llm:
+    model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 0.6
+      top_p: 0.95
+      max_tokens: 24576
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        include_reasoning: true
+    retry_config:
+      stop_after_attempt: 3
+  memory_config:
+    init_args:
+      llm_config: ${prover.summarize_output.llm}
+  summarize_output:
+    enabled: true
+    llm:
+      model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+      provider_config:
+        api_key: "local-vllm"
+        base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+        temperature: 0.6
+        top_p: 0.95
+        max_tokens: 8096
+        logprobs: true
+        top_logprobs: 20
+        streaming: false
+        max_retries: 0
+        extra_body:
+          include_reasoning: true
+      retry_config:
+        stop_after_attempt: 3
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 151936
+    require_alignment: false
+    entropy_version: reasoning_topk_v1
+runtime:
+  lean:
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/configs/paper_kimina_entropy_v5.yaml
+++ b/configs/paper_kimina_entropy_v5.yaml
@@ -1,0 +1,54 @@
+prover:
+  prover_llm:
+    model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+    structured_output_mode: json_schema_manual
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 0.6
+      top_p: 0.95
+      max_tokens: 24576
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        include_reasoning: true
+    retry_config:
+      stop_after_attempt: 3
+  memory_config:
+    init_args:
+      llm_config: ${prover.summarize_output.llm}
+  summarize_output:
+    enabled: true
+    llm:
+      model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+      structured_output_mode: json_schema_manual
+      provider_config:
+        api_key: "local-vllm"
+        base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+        temperature: 0.6
+        top_p: 0.95
+        max_tokens: 8096
+        logprobs: true
+        top_logprobs: 20
+        streaming: false
+        max_retries: 0
+        extra_body:
+          include_reasoning: true
+      retry_config:
+        stop_after_attempt: 3
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 151936
+    require_alignment: false
+    entropy_version: reasoning_topk_v1
+runtime:
+  lean:
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/configs/paper_qwen38_entropy.yaml
+++ b/configs/paper_qwen38_entropy.yaml
@@ -1,0 +1,42 @@
+prover:
+  prover_llm:
+    model: "openai:Qwen/Qwen3.8-27B-FP8"
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 1.0
+      top_p: 0.95
+      presence_penalty: 0.0
+      max_tokens: 24576
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        top_k: 20
+        min_p: 0.0
+        repetition_penalty: 1.0
+        include_reasoning: true
+        reasoning_effort: xhigh
+        chat_template_kwargs:
+          enable_thinking: true
+          preserve_thinking: true
+    retry_config:
+      stop_after_attempt: 3
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 248320
+    # Tracing must remain observational. Unaligned calls are persisted and
+    # rejected by the post-run smoke/full artifact gate, never fed back to or
+    # used to terminate the AxProver agent.
+    require_alignment: false
+    entropy_version: reasoning_topk_v1
+runtime:
+  lean:
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/configs/paper_qwen38_entropy_v3.yaml
+++ b/configs/paper_qwen38_entropy_v3.yaml
@@ -1,0 +1,68 @@
+prover:
+  prover_llm:
+    model: "openai:Qwen/Qwen3.8-27B-FP8"
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 1.0
+      top_p: 0.95
+      presence_penalty: 0.0
+      max_tokens: 24576
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        top_k: 20
+        min_p: 0.0
+        repetition_penalty: 1.0
+        include_reasoning: true
+        reasoning_effort: medium
+        chat_template_kwargs:
+          enable_thinking: true
+          preserve_thinking: true
+    retry_config:
+      stop_after_attempt: 3
+  memory_config:
+    init_args:
+      llm_config: ${prover.summarize_output.llm}
+  summarize_output:
+    enabled: true
+    llm:
+      model: "openai:Qwen/Qwen3.8-27B-FP8"
+      provider_config:
+        api_key: "local-vllm"
+        base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+        temperature: 1.0
+        top_p: 0.95
+        presence_penalty: 0.0
+        max_tokens: 8096
+        logprobs: true
+        top_logprobs: 20
+        streaming: false
+        max_retries: 0
+        extra_body:
+          top_k: 20
+          min_p: 0.0
+          repetition_penalty: 1.0
+          include_reasoning: true
+          reasoning_effort: medium
+          chat_template_kwargs:
+            enable_thinking: true
+            preserve_thinking: true
+      retry_config:
+        stop_after_attempt: 3
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 248320
+    require_alignment: false
+    entropy_version: reasoning_topk_v1
+runtime:
+  lean:
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/configs/paper_qwen38_entropy_v5.yaml
+++ b/configs/paper_qwen38_entropy_v5.yaml
@@ -1,0 +1,70 @@
+prover:
+  prover_llm:
+    model: "openai:Qwen/Qwen3.8-27B-FP8"
+    structured_output_mode: json_schema_manual
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 1.0
+      top_p: 0.95
+      presence_penalty: 0.0
+      max_tokens: 24576
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        top_k: 20
+        min_p: 0.0
+        repetition_penalty: 1.0
+        include_reasoning: true
+        reasoning_effort: medium
+        chat_template_kwargs:
+          enable_thinking: true
+          preserve_thinking: true
+    retry_config:
+      stop_after_attempt: 3
+  memory_config:
+    init_args:
+      llm_config: ${prover.summarize_output.llm}
+  summarize_output:
+    enabled: true
+    llm:
+      model: "openai:Qwen/Qwen3.8-27B-FP8"
+      structured_output_mode: json_schema_manual
+      provider_config:
+        api_key: "local-vllm"
+        base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+        temperature: 1.0
+        top_p: 0.95
+        presence_penalty: 0.0
+        max_tokens: 8096
+        logprobs: true
+        top_logprobs: 20
+        streaming: false
+        max_retries: 0
+        extra_body:
+          top_k: 20
+          min_p: 0.0
+          repetition_penalty: 1.0
+          include_reasoning: true
+          reasoning_effort: medium
+          chat_template_kwargs:
+            enable_thinking: true
+            preserve_thinking: true
+      retry_config:
+        stop_after_attempt: 3
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 248320
+    require_alignment: false
+    entropy_version: reasoning_topk_v1
+runtime:
+  lean:
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/src/ax_prover/config.py
+++ b/src/ax_prover/config.py
@@ -20,6 +20,7 @@ __all__ = [
     "LogLevel",
     "MemoryConfig",
     "ProverConfig",
+    "ReasoningTraceConfig",
     "SummarizeOutputConfig",
 ]
 
@@ -77,6 +78,20 @@ class SummarizeOutputConfig:
 
 
 @dataclass
+class ReasoningTraceConfig:
+    """Configuration for local reasoning-token traces."""
+
+    enabled: bool = False
+    output_dir: str | None = None
+    run_id: str = "manual"
+    problem_uuid: str | None = None
+    top_logprobs: int = 20
+    vocabulary_size: int | None = None
+    require_alignment: bool = True
+    entropy_version: str = "reasoning_topk_v1"
+
+
+@dataclass
 class ProverConfig:
     """Configuration for ProverAgent."""
 
@@ -87,6 +102,8 @@ class ProverConfig:
         default_factory=lambda: MemoryConfig(class_name="ExperienceProcessor")
     )
     summarize_output: SummarizeOutputConfig = field(default_factory=SummarizeOutputConfig)
+    max_input_tokens: int = 32768
+    reasoning_trace: ReasoningTraceConfig = field(default_factory=ReasoningTraceConfig)
     user_comments: str | None = None
 
 

--- a/src/ax_prover/config.py
+++ b/src/ax_prover/config.py
@@ -21,6 +21,7 @@ __all__ = [
     "MemoryConfig",
     "ProverConfig",
     "ReasoningTraceConfig",
+    "StructuredOutputMode",
     "SummarizeOutputConfig",
 ]
 
@@ -33,6 +34,13 @@ class LogLevel(StrEnum):
     WARNING = "WARNING"
     ERROR = "ERROR"
     CRITICAL = "CRITICAL"
+
+
+class StructuredOutputMode(StrEnum):
+    """How provider structured-output responses are parsed by the client."""
+
+    NATIVE_PYDANTIC = "native_pydantic"
+    JSON_SCHEMA_MANUAL = "json_schema_manual"
 
 
 DEFAULT_LLM_RETRY_CONFIG = {
@@ -59,6 +67,9 @@ class LLMConfig:
     model: str
     provider_config: dict[str, Any] = field(default_factory=dict)
     retry_config: dict[str, Any] = field(default_factory=lambda: dict(DEFAULT_LLM_RETRY_CONFIG))
+    # Keep this string-typed so OmegaConf accepts the public lower-case values
+    # used in YAML. LLMClient converts it to StructuredOutputMode and validates it.
+    structured_output_mode: str = StructuredOutputMode.NATIVE_PYDANTIC
 
 
 @dataclass

--- a/src/ax_prover/configs/default.yaml
+++ b/src/ax_prover/configs/default.yaml
@@ -15,6 +15,9 @@ prover:
   summarize_output:
     enabled: true
     llm: ${prover.prover_llm}
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: false
 runtime:
   max_tool_calling_iterations: 1
   lean:

--- a/src/ax_prover/configs/kimina_reasoning_trace.yaml
+++ b/src/ax_prover/configs/kimina_reasoning_trace.yaml
@@ -1,0 +1,48 @@
+prover:
+  prover_llm:
+    model: "openai:AI-MO/Kimina-Prover-Distill-8B"
+    provider_config:
+      api_key: "local-vllm"
+      base_url: "${oc.env:AX_PROVER_API_BASE,http://127.0.0.1:8000/v1}"
+      temperature: 0.6
+      top_p: 0.95
+      seed: 42
+      max_tokens: 8096
+      logprobs: true
+      top_logprobs: 20
+      streaming: false
+      max_retries: 0
+      extra_body:
+        include_reasoning: true
+    retry_config:
+      stop_after_attempt: 1
+  proposer_tools: {}
+  max_iterations: 6
+  memory_config:
+    class_name: MemorylessProcessor
+    init_args: {}
+  summarize_output:
+    enabled: false
+  reviewer_enabled: false
+  max_input_tokens: 32768
+  reasoning_trace:
+    enabled: true
+    output_dir: "${oc.env:AX_PROVER_TRACE_DIR}"
+    run_id: "${oc.env:RUN_ID}"
+    problem_uuid: null
+    top_logprobs: 20
+    vocabulary_size: 151936
+    require_alignment: true
+    entropy_version: reasoning_topk_v1
+  user_comments: >-
+    Use only the imports already present in the file. Return the complete target
+    theorem with a proof and do not add axioms, constants, sorry, or admit.
+
+runtime:
+  max_tool_calling_iterations: 1
+  lean:
+    cache_get_timeout: 600
+    build_timeout: 1200
+    check_file_timeout: 300
+    max_concurrent_builds: 1
+  log_level: INFO

--- a/src/ax_prover/models/messages.py
+++ b/src/ax_prover/models/messages.py
@@ -18,6 +18,7 @@ class ProposalMessage(AIMessage):
     imports: list[str] = Field(default_factory=list)
     opens: list[str] = Field(default_factory=list)
     code: str
+    trace_call_id: str | None = None
 
     def __init__(
         self,
@@ -26,6 +27,7 @@ class ProposalMessage(AIMessage):
         location: Location | None = None,
         imports: list[str] | None = None,
         opens: list[str] | None = None,
+        trace_call_id: str | None = None,
         **kwargs,
     ):
         """Initialize with auto-formatted content from structured fields."""
@@ -46,6 +48,7 @@ class ProposalMessage(AIMessage):
             imports=imports_list,
             opens=opens_list,
             code=code,
+            trace_call_id=trace_call_id,
             **kwargs,
         )
 

--- a/src/ax_prover/prover/agent.py
+++ b/src/ax_prover/prover/agent.py
@@ -1,5 +1,6 @@
 """Prover agent for creating and completing proofs in Lean 4."""
 
+import time
 from collections.abc import Sequence
 
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -50,6 +51,13 @@ from ..utils.lean_parsing import (
     list_declarations_from_file,
 )
 from ..utils.llm import LLMClient, agentic_loop, get_reasoning
+from ..utils.reasoning_trace import (
+    LLMTraceCapture,
+    LLMTraceContext,
+    ReasoningAlignmentError,
+    ReasoningTraceWriter,
+    activate_trace_capture,
+)
 from . import memory as memory_module
 from .memory import BaseMemory
 from .prompts import (
@@ -86,17 +94,29 @@ class ProverAgent:
 
         self.proposer_tools = []
 
-        self.llm_client = LLMClient(self.config.prover_llm)
+        self.llm_client = LLMClient(
+            self.config.prover_llm,
+            capture_raw_http=self.config.reasoning_trace.enabled,
+        )
+        self.reasoning_trace_writer = ReasoningTraceWriter(self.config.reasoning_trace)
+        self._trace_call_index = 0
 
         memory_class = getattr(memory_module, self.config.memory_config.class_name)
-        self.memory = memory_class(**self.config.memory_config.init_args)
+        memory_init_args = dict(self.config.memory_config.init_args)
+        memory_init_args["capture_raw_http"] = self.config.reasoning_trace.enabled
+        self.memory = memory_class(**memory_init_args)
 
         summary_llm_config = self.config.summarize_output.llm or self.config.prover_llm
-        self.summary_llm_client = LLMClient(summary_llm_config)
+        self.summary_llm_client = LLMClient(
+            summary_llm_config,
+            capture_raw_http=self.config.reasoning_trace.enabled,
+        )
 
-        self.max_input_tokens = self.llm_client.profile.get("max_input_tokens")
+        self.max_input_tokens = (
+            self.llm_client.profile.get("max_input_tokens") or self.config.max_input_tokens
+        )
         if self.max_input_tokens < 1000:
-            self.logger.error("Error: max_input_tokens abnormally small")
+            raise ValueError("max_input_tokens must be at least 1000")
 
     @classmethod
     async def create(
@@ -223,7 +243,39 @@ class ProverAgent:
 
     async def _memory_processor_node(self, state: ProverAgentState) -> dict:
         """Process memory using the configured memory strategy."""
-        return await self.memory.process(state)
+        capture = self._new_trace_capture(state, role="memory")
+        try:
+            with activate_trace_capture(capture):
+                result = await self.memory.process(state)
+        except Exception as error:
+            self.reasoning_trace_writer.record_transport_failure(capture=capture, error=error)
+            raise
+        if capture.exchanges:
+            self.reasoning_trace_writer.record_proposer(
+                capture=capture,
+                normalized_response=None,
+            )
+        return result
+
+    def _new_trace_capture(
+        self,
+        state: ProverAgentState,
+        *,
+        role: str,
+    ) -> LLMTraceCapture:
+        """Create a call identity without changing AxProver control flow."""
+
+        self._trace_call_index += 1
+        return LLMTraceCapture(
+            context=LLMTraceContext(
+                run_id=self.config.reasoning_trace.run_id,
+                problem_uuid=(self.config.reasoning_trace.problem_uuid or state.item.location.name),
+                theorem_name=state.item.location.name,
+                iteration=state.iteration_count + 1,
+                call_index=self._trace_call_index,
+                role=role,
+            )
+        )
 
     async def _proposer_node(self, state: ProverAgentState, config: RunnableConfig) -> dict:
         self.logger.info(
@@ -271,22 +323,80 @@ class ProverAgent:
             HumanMessage(content=query),
         ]
 
-        response = await agentic_loop(
-            self.llm_client,
-            context_messages,
-            tools=self.proposer_tools,
-            output_schema=ProverResult,
-            max_tool_iterations=self.runtime.config.max_tool_calling_iterations,
-        )
+        trace_capture = self._new_trace_capture(state, role="proposer")
+        trace_context = trace_capture.context
+        try:
+            response = await agentic_loop(
+                self.llm_client,
+                context_messages,
+                tools=self.proposer_tools,
+                output_schema=ProverResult,
+                max_tool_iterations=self.runtime.config.max_tool_calling_iterations,
+                trace_capture=trace_capture,
+            )
+        except Exception as error:
+            failure_summary = self.reasoning_trace_writer.record_transport_failure(
+                capture=trace_capture,
+                error=error,
+            )
+            self.reasoning_trace_writer.record_lean_check(
+                call_id=failure_summary["call_id"],
+                problem_uuid=trace_context.problem_uuid,
+                theorem_name=trace_context.theorem_name,
+                iteration=trace_context.iteration,
+                outcome="not_run_client_failure",
+                success=False,
+                feedback_type=type(error).__name__,
+                diagnostics=str(error),
+                duration_seconds=0.0,
+            )
+            if (
+                self.config.reasoning_trace.require_alignment
+                and failure_summary["alignment_status"] != "aligned"
+            ):
+                raise ReasoningAlignmentError(
+                    f"{trace_context.call_id}: {failure_summary['alignment_status']}"
+                ) from error
+            raise
+
+        try:
+            trace_summary = self.reasoning_trace_writer.record_proposer(
+                capture=trace_capture,
+                normalized_response=response,
+            )
+        except ReasoningAlignmentError as error:
+            self.reasoning_trace_writer.record_lean_check(
+                call_id=trace_context.call_id,
+                problem_uuid=trace_context.problem_uuid,
+                theorem_name=trace_context.theorem_name,
+                iteration=trace_context.iteration,
+                outcome="not_run_reasoning_trace_contract_failed",
+                success=False,
+                feedback_type=type(error).__name__,
+                diagnostics=str(error),
+                duration_seconds=0.0,
+            )
+            raise
 
         try:
             result = ProverResult.model_validate_json(response.text)
         except Exception as e:
             self.logger.error(f"Structured output parsing failed: {e}")
             feedback = StructuredOutputParsingFailedFeedback(error_message=str(e))
+            self.reasoning_trace_writer.record_lean_check(
+                call_id=trace_summary["call_id"],
+                problem_uuid=trace_context.problem_uuid,
+                theorem_name=trace_context.theorem_name,
+                iteration=trace_context.iteration,
+                outcome="not_run_structured_output_parse_failed",
+                success=False,
+                feedback_type=feedback.feedback_type,
+                diagnostics=str(e),
+                duration_seconds=0.0,
+            )
             return {"messages": [feedback]}
 
-        reasoning = get_reasoning(response)
+        reasoning = trace_summary.get("reasoning") or get_reasoning(response)
         self.logger.info(f"[Iteration {state.iteration_count + 1}] Generated proof")
         self.logger.debug(f"Proposer reasoning: \n{reasoning}")
         self.logger.debug(f"Code: \n{result.updated_theorem}")
@@ -297,10 +407,37 @@ class ProverAgent:
             imports=result.imports,
             opens=result.opens,
             code=result.updated_theorem,
+            trace_call_id=trace_summary["call_id"],
         )
         return {"messages": [proposal]}
 
     async def _builder_node(self, state: ProverAgentState) -> dict:
+        started_at = time.monotonic()
+        try:
+            result = await self._run_builder_node(state)
+        except Exception as error:
+            self._record_lean_check(
+                state=state,
+                feedback_type=type(error).__name__,
+                outcome="builder_exception",
+                success=False,
+                diagnostics=str(error),
+                duration_seconds=time.monotonic() - started_at,
+            )
+            raise
+
+        feedback = result.get("messages", [None])[-1]
+        self._record_lean_check(
+            state=state,
+            feedback_type=getattr(feedback, "feedback_type", type(feedback).__name__),
+            outcome=getattr(feedback, "feedback_type", "builder_unknown"),
+            success=bool(getattr(feedback, "is_success", False)),
+            diagnostics=getattr(feedback, "content", ""),
+            duration_seconds=time.monotonic() - started_at,
+        )
+        return result
+
+    async def _run_builder_node(self, state: ProverAgentState) -> dict:
         self.logger.info(
             f"Testing code at: {state.item.location.formatted_context if state.item.location else 'unknown'}"
         )
@@ -385,6 +522,29 @@ class ProverAgent:
             "metrics": state.metrics,
         }
 
+    def _record_lean_check(
+        self,
+        *,
+        state: ProverAgentState,
+        feedback_type: str,
+        outcome: str,
+        success: bool,
+        diagnostics: str,
+        duration_seconds: float,
+    ) -> None:
+        proposal = state.last_proposal
+        self.reasoning_trace_writer.record_lean_check(
+            call_id=proposal.trace_call_id if proposal else None,
+            problem_uuid=(self.config.reasoning_trace.problem_uuid or state.item.location.name),
+            theorem_name=state.item.location.name,
+            iteration=state.iteration_count,
+            outcome=outcome,
+            success=success,
+            feedback_type=feedback_type,
+            diagnostics=diagnostics,
+            duration_seconds=duration_seconds,
+        )
+
     async def _reviewer_node(self, state: ProverAgentState, config: RunnableConfig) -> dict:
         self.logger.info("Reviewing proof")
 
@@ -404,7 +564,23 @@ class ProverAgent:
             HumanMessage(content=query),
         ]
 
-        response = await self.llm_client.ainvoke(messages, output_schema=ReviewDecision)
+        trace_capture = self._new_trace_capture(state, role="reviewer")
+        try:
+            response = await self.llm_client.ainvoke(
+                messages,
+                output_schema=ReviewDecision,
+                trace_capture=trace_capture,
+            )
+        except Exception as error:
+            self.reasoning_trace_writer.record_transport_failure(
+                capture=trace_capture,
+                error=error,
+            )
+            raise
+        self.reasoning_trace_writer.record_proposer(
+            capture=trace_capture,
+            normalized_response=response,
+        )
         try:
             review_result = ReviewDecision.model_validate_json(response.text)
         except Exception as e:
@@ -492,11 +668,24 @@ class ProverAgent:
             experience=state.experience or "No experience recorded",
         )
 
-        response = await self.summary_llm_client.ainvoke(
-            [
-                SystemMessage(content=SUMMARIZE_OUTPUT_SYSTEM_PROMPT),
-                HumanMessage(content=query),
-            ]
+        trace_capture = self._new_trace_capture(state, role="summarizer")
+        try:
+            response = await self.summary_llm_client.ainvoke(
+                [
+                    SystemMessage(content=SUMMARIZE_OUTPUT_SYSTEM_PROMPT),
+                    HumanMessage(content=query),
+                ],
+                trace_capture=trace_capture,
+            )
+        except Exception as error:
+            self.reasoning_trace_writer.record_transport_failure(
+                capture=trace_capture,
+                error=error,
+            )
+            raise
+        self.reasoning_trace_writer.record_proposer(
+            capture=trace_capture,
+            normalized_response=response,
         )
 
         summary = response.text
@@ -553,6 +742,15 @@ class ProverAgent:
         except Exception as e:
             self.logger.error(f"Error: {e}")
             raise
+
+    async def aclose(self) -> None:
+        """Close HTTP clients owned by this agent."""
+
+        await self.llm_client.aclose()
+        if self.memory.llm is not None:
+            await self.memory.llm.aclose()
+        if self.summary_llm_client is not self.llm_client:
+            await self.summary_llm_client.aclose()
 
 
 async def _detect_cheats_in_code(

--- a/src/ax_prover/prover/memory.py
+++ b/src/ax_prover/prover/memory.py
@@ -17,9 +17,17 @@ class BaseMemory(ABC):
 
     llm: LLMClient | None = None
 
-    def __init__(self, llm_config: LLMConfig | None = None):
+    def __init__(
+        self,
+        llm_config: LLMConfig | None = None,
+        *,
+        capture_raw_http: bool = False,
+    ):
         if llm_config:
-            self.llm = LLMClient(LLMConfig(**llm_config))
+            self.llm = LLMClient(
+                LLMConfig(**llm_config),
+                capture_raw_http=capture_raw_http,
+            )
 
         self.logger = get_logger(__name__)
 
@@ -53,8 +61,10 @@ class PreviousKProcessor(BaseMemory):
         self,
         llm_config: LLMConfig | None = None,
         k: int = 1,
+        *,
+        capture_raw_http: bool = False,
     ):
-        super().__init__(llm_config=llm_config)
+        super().__init__(llm_config=llm_config, capture_raw_http=capture_raw_http)
         self.k = k
 
     def _find_previous_proposal(

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpx
 from anthropic import transform_schema
 from langchain.chat_models import init_chat_model
 from langchain_anthropic import ChatAnthropic
@@ -16,6 +17,11 @@ from langgraph.prebuilt import ToolNode
 from pydantic import BaseModel
 
 from ..config import LLMConfig
+from .reasoning_trace import (
+    LLMTraceCapture,
+    activate_trace_capture,
+    capture_httpx_response,
+)
 
 _PROVIDER_API_KEY_ENV = {
     "anthropic": "ANTHROPIC_API_KEY",
@@ -24,16 +30,27 @@ _PROVIDER_API_KEY_ENV = {
 }
 
 
-def create_llm(config: LLMConfig) -> BaseChatModel:
+def create_llm(
+    config: LLMConfig,
+    *,
+    http_async_client: httpx.AsyncClient | None = None,
+) -> BaseChatModel:
     """Create an LLM instance from configuration."""
     provider = config.model.split(":")[0] if ":" in config.model else None
     key_env = _PROVIDER_API_KEY_ENV.get(provider)
-    if key_env and not os.environ.get(key_env):
+    if key_env and not os.environ.get(key_env) and not config.provider_config.get("api_key"):
         raise OSError(f"{key_env} is not set. Check your .env.secrets file.")
 
+    provider_config = dict(config.provider_config)
+    if http_async_client is not None:
+        if provider_config.get("http_async_client") is not None:
+            raise ValueError(
+                "http_async_client cannot be supplied when raw HTTP capture is enabled"
+            )
+        provider_config["http_async_client"] = http_async_client
     return init_chat_model(
         config.model,
-        **config.provider_config,
+        **provider_config,
     )
 
 
@@ -43,14 +60,19 @@ async def agentic_loop(
     tools: list[BaseTool],
     output_schema: type[BaseModel] | None = None,
     max_tool_iterations: int = 5,
-) -> tuple[AIMessage, list[BaseMessage]]:
+    trace_capture: LLMTraceCapture | None = None,
+) -> AIMessage:
     """Invoke an LLM with tools, executing tool calls in a loop until the model stops calling tools.
 
     Returns:
-        A tuple of (final_response, all_new_messages) where all_new_messages includes every
-        intermediate AI message, tool result, and the final response.
+        The final model response after any requested tool calls have completed.
     """
-    response = await client.ainvoke(messages, tools=tools, output_schema=output_schema)
+    response = await client.ainvoke(
+        messages,
+        tools=tools,
+        output_schema=output_schema,
+        trace_capture=trace_capture,
+    )
     new_messages: list[BaseMessage] = [response]
 
     tool_node = ToolNode(tools)
@@ -70,10 +92,17 @@ async def agentic_loop(
             invoke_messages = invoke_messages + [
                 HumanMessage(content="NO MORE TOOL CALLS ALLOWED.")
             ]
-            response = await client.ainvoke(invoke_messages, output_schema=output_schema)
+            response = await client.ainvoke(
+                invoke_messages,
+                output_schema=output_schema,
+                trace_capture=trace_capture,
+            )
         else:
             response = await client.ainvoke(
-                invoke_messages, tools=tools, output_schema=output_schema
+                invoke_messages,
+                tools=tools,
+                output_schema=output_schema,
+                trace_capture=trace_capture,
             )
 
         new_messages.append(response)
@@ -83,10 +112,16 @@ async def agentic_loop(
 
 def get_reasoning(response: AIMessage) -> str:
     """Extract the reasoning from an LLM response."""
-    reasoning = "\n\n".join(
-        [msg.get("reasoning", "") for msg in response.content_blocks if msg["type"] == "reasoning"]
-    )
-    return reasoning
+    for field_name in ("reasoning", "reasoning_content"):
+        value = response.additional_kwargs.get(field_name)
+        if isinstance(value, str) and value:
+            return value
+    values = [
+        str(block.get("reasoning") or block.get("text") or "")
+        for block in response.content_blocks
+        if isinstance(block, dict) and block.get("type") == "reasoning"
+    ]
+    return "\n\n".join(value for value in values if value)
 
 
 class LLMClient:
@@ -114,15 +149,30 @@ class LLMClient:
         response = await client.ainvoke(messages, retry_config={"stop_after_attempt": 3})
     """
 
-    def __init__(self, config: LLMConfig):
+    def __init__(self, config: LLMConfig, *, capture_raw_http: bool = False):
         """Initialize the LLMClient with a configuration."""
-        self._base_llm: BaseChatModel = create_llm(config)
+        provider = config.model.split(":", 1)[0] if ":" in config.model else None
+        if capture_raw_http and provider != "openai":
+            raise ValueError("Raw HTTP tracing currently requires the OpenAI provider")
+        self._trace_http_client = (
+            httpx.AsyncClient(
+                event_hooks={"response": [capture_httpx_response]},
+                timeout=None,
+            )
+            if capture_raw_http
+            else None
+        )
+        self._base_llm: BaseChatModel = create_llm(
+            config,
+            http_async_client=self._trace_http_client,
+        )
         self._retry_config: dict = config.retry_config
 
     @property
     def profile(self) -> dict:
         """Model metadata (max_input_tokens, max_output_tokens, capabilities, etc.)."""
-        return getattr(self._base_llm, "profile", {})
+        profile = getattr(self._base_llm, "profile", None)
+        return profile if isinstance(profile, dict) else {}
 
     async def ainvoke(
         self,
@@ -130,13 +180,20 @@ class LLMClient:
         tools: list[BaseTool] | None = None,
         output_schema: type[BaseModel] | None = None,
         retry_config: dict | None = None,
+        trace_capture: LLMTraceCapture | None = None,
     ) -> AIMessage:
         """Invoke with optional tools, structured output, and retry."""
         effective_retry = retry_config or self._retry_config
         runnable = self._get_runnable(
             tools=tools, output_schema=output_schema, retry_config=effective_retry
         )
-        return await runnable.ainvoke(messages)
+        with activate_trace_capture(trace_capture):
+            return await runnable.ainvoke(messages)
+
+    async def aclose(self) -> None:
+        """Close the optional tracing HTTP client."""
+        if self._trace_http_client is not None:
+            await self._trace_http_client.aclose()
 
     def _get_runnable(
         self,

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -11,12 +11,13 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_function
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import ToolNode
 from pydantic import BaseModel
 
-from ..config import LLMConfig
+from ..config import LLMConfig, StructuredOutputMode
 from .reasoning_trace import (
     LLMTraceCapture,
     activate_trace_capture,
@@ -167,6 +168,7 @@ class LLMClient:
             http_async_client=self._trace_http_client,
         )
         self._retry_config: dict = config.retry_config
+        self._structured_output_mode = StructuredOutputMode(config.structured_output_mode)
 
     @property
     def profile(self) -> dict:
@@ -231,6 +233,15 @@ class LLMClient:
         # LANGCHAIN PLSSS ALLOW ME TO DO STRUCTURED OUTPUT WITH TOOL BINDINGS
         # LOOK AT WHAT IT NEED TO DO C'MONNNNN
 
+        if (
+            self._structured_output_mode is StructuredOutputMode.JSON_SCHEMA_MANUAL
+            and not isinstance(self._base_llm, ChatOpenAI)
+        ):
+            raise ValueError(
+                "structured_output_mode=json_schema_manual requires an OpenAI-compatible "
+                "ChatOpenAI provider"
+            )
+
         if isinstance(self._base_llm, ChatAnthropic):
             model_name = getattr(self._base_llm, "model", "")  # Need to check 4.5 or 4.6+
             return _anthropic_structured_kwargs(model_name, schema)
@@ -239,7 +250,7 @@ class LLMClient:
             return _google_structured_kwargs(schema.model_json_schema())
 
         if isinstance(self._base_llm, ChatOpenAI):
-            return _openai_structured_kwargs(schema)
+            return _openai_structured_kwargs(schema, self._structured_output_mode)
 
         raise NotImplementedError(
             f"Structured output bind kwargs not implemented for {type(self._base_llm).__name__}."
@@ -271,5 +282,34 @@ def _google_structured_kwargs(schema: type[BaseModel]) -> dict:
     }
 
 
-def _openai_structured_kwargs(schema: type[BaseModel]) -> dict:
-    return {"response_format": schema}
+def _openai_structured_kwargs(
+    schema: type[BaseModel],
+    mode: StructuredOutputMode = StructuredOutputMode.NATIVE_PYDANTIC,
+) -> dict:
+    """Build native or manually parsed OpenAI structured-output arguments.
+
+    The manual mode deliberately passes a plain response-format dictionary. The
+    OpenAI SDK still sends the same strict JSON-schema constraint to the server,
+    but it does not eagerly parse non-empty assistant content as the Pydantic
+    model before AxProver can inspect sibling tool calls.
+    """
+    if mode is StructuredOutputMode.NATIVE_PYDANTIC:
+        return {"response_format": schema}
+
+    if mode is not StructuredOutputMode.JSON_SCHEMA_MANUAL:
+        raise ValueError(f"Unsupported structured output mode: {mode}")
+
+    function = convert_to_openai_function(schema, strict=True)
+    parameters = function.get("parameters")
+    if not isinstance(parameters, dict):
+        raise ValueError(f"Could not derive a JSON schema for {schema.__name__}")
+    return {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": function["name"],
+                "strict": True,
+                "schema": parameters,
+            },
+        }
+    }

--- a/src/ax_prover/utils/reasoning_trace.py
+++ b/src/ax_prover/utils/reasoning_trace.py
@@ -1,0 +1,912 @@
+"""Lossless vLLM reasoning traces and top-K entropy metrics."""
+
+from __future__ import annotations
+
+import contextvars
+import gzip
+import hashlib
+import json
+import math
+import os
+import statistics
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ..config import ReasoningTraceConfig
+
+
+class ReasoningTraceError(RuntimeError):
+    """Base error for reasoning-trace contract failures."""
+
+
+class ReasoningAlignmentError(ReasoningTraceError):
+    """Raised when reasoning cannot be aligned to provider logprob tokens."""
+
+
+@dataclass(frozen=True)
+class LLMTraceContext:
+    """Stable identity for one model call."""
+
+    run_id: str
+    problem_uuid: str
+    theorem_name: str
+    iteration: int
+    call_index: int
+    role: str
+
+    @property
+    def call_id(self) -> str:
+        return f"{self.run_id}:{self.problem_uuid}:{self.role}:{self.iteration}:{self.call_index}"
+
+
+@dataclass
+class RawHTTPExchange:
+    """One HTTP response captured before LangChain normalizes it."""
+
+    captured_at: str
+    method: str
+    url: str
+    status_code: int
+    request_headers: dict[str, str]
+    response_headers: dict[str, str]
+    request_body_utf8: str
+    response_body_utf8: str
+
+    def request_json(self) -> Any:
+        return _load_json(self.request_body_utf8)
+
+    def response_json(self) -> Any:
+        return _load_json(self.response_body_utf8)
+
+
+@dataclass
+class LLMTraceCapture:
+    """Mutable capture populated by the HTTP response hook during one call."""
+
+    context: LLMTraceContext
+    exchanges: list[RawHTTPExchange] = field(default_factory=list)
+    started_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    started_monotonic: float = field(default_factory=time.monotonic)
+
+    @property
+    def successful_exchange(self) -> RawHTTPExchange | None:
+        for exchange in reversed(self.exchanges):
+            payload = exchange.response_json()
+            if 200 <= exchange.status_code < 300 and isinstance(payload, dict):
+                if isinstance(payload.get("choices"), list):
+                    return exchange
+        return None
+
+
+_ACTIVE_CAPTURE: contextvars.ContextVar[LLMTraceCapture | None] = contextvars.ContextVar(
+    "ax_prover_reasoning_trace_capture", default=None
+)
+
+
+def current_trace_capture() -> LLMTraceCapture | None:
+    """Return the call-local trace identity without changing capture state."""
+
+    return _ACTIVE_CAPTURE.get()
+
+
+@contextmanager
+def activate_trace_capture(capture: LLMTraceCapture | None) -> Iterator[None]:
+    """Expose a call-local capture to the async HTTP response hook."""
+
+    if capture is None:
+        yield
+        return
+    token = _ACTIVE_CAPTURE.set(capture)
+    try:
+        yield
+    finally:
+        _ACTIVE_CAPTURE.reset(token)
+
+
+async def capture_httpx_response(response: httpx.Response) -> None:
+    """Capture an OpenAI-compatible response before model-specific parsing."""
+
+    capture = _ACTIVE_CAPTURE.get()
+    if capture is None:
+        return
+    body = await response.aread()
+    request = response.request
+    capture.exchanges.append(
+        RawHTTPExchange(
+            captured_at=_now(),
+            method=request.method,
+            url=str(request.url),
+            status_code=response.status_code,
+            request_headers=_safe_headers(request.headers),
+            response_headers=_safe_headers(response.headers),
+            request_body_utf8=request.content.decode("utf-8", errors="replace"),
+            response_body_utf8=body.decode("utf-8", errors="replace"),
+        )
+    )
+
+
+def analyze_provider_payload(
+    payload: dict[str, Any],
+    *,
+    vocabulary_size: int | None,
+) -> dict[str, Any]:
+    """Align reasoning with provider logprobs and compute token metrics."""
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        return _analysis_failure("provider_choices_missing")
+    choice = choices[0]
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        return _analysis_failure("provider_message_missing")
+
+    reasoning, reasoning_field = _provider_reasoning(message)
+    final_content = message.get("content")
+    if not isinstance(final_content, str):
+        final_content = ""
+    truncated_open_think = (
+        not reasoning
+        and choice.get("finish_reason") == "length"
+        and final_content.startswith("<think>")
+        and "</think>" not in final_content
+    )
+    if truncated_open_think:
+        # qwen3 cannot close its reasoning delimiter after a length stop. vLLM
+        # therefore leaves the truncated trace in content instead of exposing a
+        # reasoning field. The bytes after the opening delimiter are still an
+        # exact, auditable reasoning region; there is intentionally no final output.
+        reasoning = final_content[len("<think>") :]
+        reasoning_field = "content_unclosed_think_truncated"
+        final_content = ""
+    if not reasoning:
+        return {
+            **_analysis_failure("reasoning_missing"),
+            "reasoning": reasoning,
+            "reasoning_field": reasoning_field,
+            "final_content": final_content,
+        }
+
+    logprobs = choice.get("logprobs")
+    entries = logprobs.get("content") if isinstance(logprobs, dict) else None
+    if not isinstance(entries, list) or not entries:
+        return {
+            **_analysis_failure("logprobs_missing"),
+            "reasoning": reasoning,
+            "reasoning_field": reasoning_field,
+            "final_content": final_content,
+        }
+
+    try:
+        token_bytes = [_entry_bytes(entry) for entry in entries]
+    except ReasoningAlignmentError as error:
+        return {
+            **_analysis_failure("invalid_logprob_token_entry"),
+            "reasoning": reasoning,
+            "reasoning_field": reasoning_field,
+            "final_content": final_content,
+            "alignment_error": str(error),
+        }
+    generated = b"".join(token_bytes)
+    boundaries = [0]
+    for item in token_bytes:
+        boundaries.append(boundaries[-1] + len(item))
+    boundary_set = set(boundaries)
+    opening_delimiters = [
+        index for index, entry in enumerate(entries) if entry.get("token") == "<think>"
+    ]
+    closing_delimiters = [
+        index for index, entry in enumerate(entries) if entry.get("token") == "</think>"
+    ]
+    reasoning_delimiter_span = (
+        len(opening_delimiters) == 1
+        and bool(closing_delimiters)
+        and opening_delimiters[0] < closing_delimiters[0]
+    )
+    closed_delimiter_span = (
+        len(opening_delimiters) == 1
+        and len(closing_delimiters) == 1
+        and opening_delimiters[0] < closing_delimiters[0]
+    )
+    alignment_basis = "provider_reasoning_content_span"
+    if reasoning and reasoning_delimiter_span:
+        token_start = opening_delimiters[0] + 1
+        token_end = closing_delimiters[0]
+        byte_start = boundaries[token_start]
+        byte_end = boundaries[token_end]
+        alignment_basis = (
+            "qwen3_delimiter_token_span"
+            if closed_delimiter_span
+            else "qwen3_first_closing_delimiter_token_span"
+        )
+    elif truncated_open_think:
+        opening_end = len(b"<think>")
+        if not generated.startswith(b"<think>"):
+            return {
+                **_analysis_failure("truncated_reasoning_opening_delimiter_missing"),
+                "reasoning": reasoning,
+                "reasoning_field": reasoning_field,
+                "final_content": final_content,
+            }
+        if opening_end not in boundary_set:
+            return {
+                **_analysis_failure("truncated_reasoning_delimiter_splits_token"),
+                "reasoning": reasoning,
+                "reasoning_field": reasoning_field,
+                "final_content": final_content,
+            }
+        byte_start = opening_end
+        byte_end = len(generated)
+        alignment_basis = "opening_think_delimiter_to_length_stop"
+    else:
+        reasoning_bytes = reasoning.encode("utf-8")
+        occurrence_starts: list[int] = []
+        search_from = 0
+        while True:
+            occurrence = generated.find(reasoning_bytes, search_from)
+            if occurrence < 0:
+                break
+            occurrence_starts.append(occurrence)
+            search_from = occurrence + 1
+        if not occurrence_starts:
+            return {
+                **_analysis_failure("reasoning_not_found_in_logprob_tokens"),
+                "reasoning": reasoning,
+                "reasoning_field": reasoning_field,
+                "final_content": final_content,
+                "generated_text": generated.decode("utf-8", errors="replace"),
+            }
+        aligned_starts = [
+            start
+            for start in occurrence_starts
+            if start in boundary_set and start + len(reasoning_bytes) in boundary_set
+        ]
+        if not aligned_starts:
+            return {
+                **_analysis_failure("reasoning_boundary_splits_token"),
+                "reasoning": reasoning,
+                "reasoning_field": reasoning_field,
+                "final_content": final_content,
+                "candidate_byte_starts": occurrence_starts,
+            }
+        if len(aligned_starts) > 1:
+            return {
+                **_analysis_failure("reasoning_alignment_ambiguous"),
+                "reasoning": reasoning,
+                "reasoning_field": reasoning_field,
+                "final_content": final_content,
+            }
+        byte_start = aligned_starts[0]
+        byte_end = byte_start + len(reasoning_bytes)
+    if not reasoning_delimiter_span:
+        try:
+            token_start = boundaries.index(byte_start)
+            token_end = boundaries.index(byte_end)
+        except ValueError:
+            return {
+                **_analysis_failure("reasoning_boundary_splits_token"),
+                "reasoning": reasoning,
+                "reasoning_field": reasoning_field,
+                "final_content": final_content,
+                "reasoning_byte_start": byte_start,
+                "reasoning_byte_end": byte_end,
+            }
+
+    reasoning_entries = entries[token_start:token_end]
+    token_records: list[dict[str, Any]] = []
+    for reasoning_position, entry in enumerate(reasoning_entries):
+        generated_position = token_start + reasoning_position
+        token_records.append(
+            {
+                "generated_position": generated_position,
+                "reasoning_position": reasoning_position,
+                "position_fraction": (reasoning_position / max(1, len(reasoning_entries) - 1)),
+                "token": str(entry.get("token") or ""),
+                "bytes": entry.get("bytes"),
+                "sampled_logprob": _finite_float(entry.get("logprob")),
+                "top_logprobs": entry.get("top_logprobs") or [],
+                **_token_entropy_metrics(entry, vocabulary_size=vocabulary_size),
+            }
+        )
+
+    decoded_reasoning = b"".join(token_bytes[token_start:token_end]).decode(
+        "utf-8", errors="strict"
+    )
+    reasoning_decode_matches_provider = decoded_reasoning == reasoning
+    if (
+        not truncated_open_think
+        and not reasoning_delimiter_span
+        and not reasoning_decode_matches_provider
+    ):
+        return {
+            **_analysis_failure("reasoning_decode_mismatch"),
+            "reasoning": reasoning,
+            "reasoning_field": reasoning_field,
+            "final_content": final_content,
+            "decoded_reasoning": decoded_reasoning,
+        }
+
+    final_alignment_status = "empty"
+    final_token_start = None
+    final_token_end = None
+    final_token_records: list[dict[str, Any]] = []
+    final_decode_matches_provider = None
+    if final_content and closed_delimiter_span:
+        final_token_start = closing_delimiters[0] + 1
+        final_token_end = len(entries)
+        if final_token_end > final_token_start and entries[-1].get("token") == "<|im_end|>":
+            final_token_end -= 1
+        final_alignment_status = "aligned"
+        for final_position, entry in enumerate(entries[final_token_start:final_token_end]):
+            final_token_records.append(
+                {
+                    "generated_position": final_token_start + final_position,
+                    "final_position": final_position,
+                    "token": str(entry.get("token") or ""),
+                    "bytes": entry.get("bytes"),
+                    "sampled_logprob": _finite_float(entry.get("logprob")),
+                    "top_logprobs": entry.get("top_logprobs") or [],
+                }
+            )
+        decoded_final = b"".join(token_bytes[final_token_start:final_token_end]).decode(
+            "utf-8", errors="strict"
+        )
+        final_decode_matches_provider = decoded_final == final_content
+    elif final_content:
+        final_bytes = final_content.encode("utf-8")
+        final_byte_start = generated.find(final_bytes, byte_end)
+        if final_byte_start < 0:
+            final_alignment_status = "final_content_not_found_in_logprob_tokens"
+        else:
+            final_byte_end = final_byte_start + len(final_bytes)
+            try:
+                final_token_start = boundaries.index(final_byte_start)
+                final_token_end = boundaries.index(final_byte_end)
+            except ValueError:
+                final_alignment_status = "final_content_boundary_splits_token"
+            else:
+                final_alignment_status = "aligned"
+                for final_position, entry in enumerate(entries[final_token_start:final_token_end]):
+                    final_token_records.append(
+                        {
+                            "generated_position": final_token_start + final_position,
+                            "final_position": final_position,
+                            "token": str(entry.get("token") or ""),
+                            "bytes": entry.get("bytes"),
+                            "sampled_logprob": _finite_float(entry.get("logprob")),
+                            "top_logprobs": entry.get("top_logprobs") or [],
+                        }
+                    )
+                decoded_final = b"".join(token_bytes[final_token_start:final_token_end]).decode(
+                    "utf-8", errors="strict"
+                )
+                final_decode_matches_provider = decoded_final == final_content
+
+    return {
+        "alignment_status": "aligned",
+        "alignment_basis": alignment_basis,
+        "reasoning_decode_matches_provider": reasoning_decode_matches_provider,
+        "reasoning": reasoning,
+        "reasoning_field": reasoning_field,
+        "final_content": final_content,
+        "final_content_field": "content",
+        "reasoning_byte_start": byte_start,
+        "reasoning_byte_end": byte_end,
+        "reasoning_token_start": token_start,
+        "reasoning_token_end": token_end,
+        "generated_token_count": len(entries),
+        "reasoning_token_count": len(token_records),
+        "final_alignment_status": final_alignment_status,
+        "final_decode_matches_provider": final_decode_matches_provider,
+        "final_token_start": final_token_start,
+        "final_token_end": final_token_end,
+        "final_token_count": len(final_token_records),
+        "final_tokens": final_token_records,
+        "tokens": token_records,
+        "aggregates": _aggregate_tokens(token_records),
+        "finish_reason": choice.get("finish_reason"),
+        "usage": payload.get("usage"),
+    }
+
+
+class ReasoningTraceWriter:
+    """Append reasoning calls, token metrics, and Lean outcomes under scratch."""
+
+    def __init__(self, config: ReasoningTraceConfig):
+        self.config = config
+        if config.enabled and not config.output_dir:
+            raise ValueError("reasoning_trace.output_dir is required when tracing is enabled")
+        self.output_dir = (
+            Path(config.output_dir).expanduser().resolve() if config.output_dir else None
+        )
+        if self.output_dir:
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enabled
+
+    def record_proposer(
+        self,
+        *,
+        capture: LLMTraceCapture,
+        normalized_response: Any,
+    ) -> dict[str, Any]:
+        """Persist every provider call in a node and return the final call summary."""
+
+        if not self.enabled or self.output_dir is None:
+            return {"call_id": capture.context.call_id, "alignment_status": "disabled"}
+
+        exchange_groups: list[list[RawHTTPExchange]] = []
+        pending: list[RawHTTPExchange] = []
+        for exchange in capture.exchanges:
+            pending.append(exchange)
+            payload = exchange.response_json()
+            if (
+                200 <= exchange.status_code < 300
+                and isinstance(payload, dict)
+                and isinstance(payload.get("choices"), list)
+            ):
+                exchange_groups.append(pending)
+                pending = []
+        if not exchange_groups:
+            exchange_groups = [[]]
+        summaries = []
+        for exchange_index, exchange_group in enumerate(exchange_groups):
+            summaries.append(
+                self._record_exchange(
+                    capture=capture,
+                    exchange_group=exchange_group,
+                    exchange_index=exchange_index,
+                    exchange_count=len(exchange_groups),
+                    normalized_response=(
+                        normalized_response if exchange_index == len(exchange_groups) - 1 else None
+                    ),
+                )
+            )
+        return summaries[-1]
+
+    def _record_exchange(
+        self,
+        *,
+        capture: LLMTraceCapture,
+        exchange_group: list[RawHTTPExchange],
+        exchange_index: int,
+        exchange_count: int,
+        normalized_response: Any,
+        terminal_error: BaseException | None = None,
+        enforce_alignment: bool = True,
+    ) -> dict[str, Any]:
+        exchange = exchange_group[-1] if exchange_group else None
+        provider_payload = exchange.response_json() if exchange else None
+        if isinstance(provider_payload, dict):
+            analysis = analyze_provider_payload(
+                provider_payload,
+                vocabulary_size=self.config.vocabulary_size,
+            )
+        else:
+            analysis = {
+                **_analysis_failure("successful_provider_response_missing"),
+                "reasoning": _normalized_reasoning(normalized_response),
+                "reasoning_field": "langchain_fallback",
+                "final_content": _normalized_text(normalized_response),
+            }
+
+        context = asdict(capture.context)
+        role = context["role"]
+        call_id = capture.context.call_id
+        if exchange_index:
+            role = "tool_continuation"
+            call_id = f"{capture.context.call_id}:tool:{exchange_index}"
+        context.update(
+            role=role,
+            exchange_index=exchange_index,
+            exchange_count=exchange_count,
+            parent_call_id=capture.context.call_id if exchange_index else None,
+        )
+        request_payload = exchange.request_json() if exchange else None
+        call_record = {
+            "schema_version": 1,
+            "entropy_version": self.config.entropy_version,
+            "started_at": capture.started_at,
+            "captured_at": _now(),
+            "latency_seconds": round(time.monotonic() - capture.started_monotonic, 6),
+            "call_id": call_id,
+            **context,
+            "prompt_hash": _exchange_request_hash(exchange),
+            "response_hash": _exchange_response_hash(exchange),
+            "request": request_payload,
+            "decoder_settings": _decoder_settings(request_payload),
+            "provider_response": provider_payload,
+            "raw_http_exchanges": [asdict(item) for item in exchange_group],
+            "langchain_response": _normalized_response_dump(normalized_response),
+            "alignment_status": analysis["alignment_status"],
+            "alignment_basis": analysis.get("alignment_basis"),
+            "reasoning_decode_matches_provider": analysis.get("reasoning_decode_matches_provider"),
+            "reasoning_field": analysis.get("reasoning_field"),
+            "reasoning": analysis.get("reasoning", ""),
+            "final_content": analysis.get("final_content", ""),
+            "final_content_field": analysis.get("final_content_field", "content"),
+            "reasoning_token_start": analysis.get("reasoning_token_start"),
+            "reasoning_token_end": analysis.get("reasoning_token_end"),
+            "reasoning_token_count": analysis.get("reasoning_token_count", 0),
+            "generated_token_count": analysis.get("generated_token_count"),
+            "final_alignment_status": analysis.get("final_alignment_status"),
+            "final_decode_matches_provider": analysis.get("final_decode_matches_provider"),
+            "final_token_start": analysis.get("final_token_start"),
+            "final_token_end": analysis.get("final_token_end"),
+            "final_token_count": analysis.get("final_token_count", 0),
+            "finish_reason": analysis.get("finish_reason"),
+            "usage": analysis.get("usage"),
+            "reasoning_aggregates": analysis.get("aggregates", {}),
+        }
+        if terminal_error is not None:
+            call_record.update(
+                error_type=type(terminal_error).__name__,
+                error=str(terminal_error),
+            )
+        _append_jsonl(self.output_dir / "llm_calls.jsonl", call_record)
+
+        reasoning_records = [
+            {
+                "schema_version": 1,
+                "entropy_version": self.config.entropy_version,
+                "call_id": call_id,
+                **context,
+                **token_record,
+            }
+            for token_record in analysis.get("tokens", [])
+        ]
+        _append_gzip_jsonl_many(self.output_dir / "reasoning_tokens.jsonl.gz", reasoning_records)
+
+        final_records = [
+            {
+                "schema_version": 1,
+                "region": "structured_final_output",
+                "call_id": call_id,
+                **context,
+                **token_record,
+            }
+            for token_record in analysis.get("final_tokens", [])
+        ]
+        _append_gzip_jsonl_many(self.output_dir / "final_tokens.jsonl.gz", final_records)
+
+        if (
+            enforce_alignment
+            and analysis["alignment_status"] != "aligned"
+            and self.config.require_alignment
+        ):
+            raise ReasoningAlignmentError(f"{call_id}: {analysis['alignment_status']}")
+        if (
+            enforce_alignment
+            and analysis.get("final_content")
+            and analysis.get("final_alignment_status") != "aligned"
+            and self.config.require_alignment
+        ):
+            raise ReasoningAlignmentError(f"{call_id}: {analysis['final_alignment_status']}")
+        return {
+            "call_id": call_id,
+            "alignment_status": analysis["alignment_status"],
+            "reasoning": analysis.get("reasoning", ""),
+            "reasoning_token_count": analysis.get("reasoning_token_count", 0),
+            "finish_reason": analysis.get("finish_reason"),
+            "aggregates": analysis.get("aggregates", {}),
+        }
+
+    def record_transport_failure(
+        self,
+        *,
+        capture: LLMTraceCapture,
+        error: BaseException,
+    ) -> dict[str, Any]:
+        """Persist every provider attempt and recover metrics when normalization raises."""
+
+        if not self.enabled or self.output_dir is None:
+            return {"call_id": capture.context.call_id, "alignment_status": "disabled"}
+        exchange_groups: list[list[RawHTTPExchange]] = []
+        pending: list[RawHTTPExchange] = []
+        for exchange in capture.exchanges:
+            pending.append(exchange)
+            payload = exchange.response_json()
+            if (
+                200 <= exchange.status_code < 300
+                and isinstance(payload, dict)
+                and isinstance(payload.get("choices"), list)
+            ):
+                exchange_groups.append(pending)
+                pending = []
+        if pending:
+            exchange_groups.append(pending)
+        if not exchange_groups:
+            exchange_groups = [[]]
+
+        summaries = []
+        for exchange_index, exchange_group in enumerate(exchange_groups):
+            summaries.append(
+                self._record_exchange(
+                    capture=capture,
+                    exchange_group=exchange_group,
+                    exchange_index=exchange_index,
+                    exchange_count=len(exchange_groups),
+                    normalized_response=None,
+                    terminal_error=(error if exchange_index == len(exchange_groups) - 1 else None),
+                    enforce_alignment=False,
+                )
+            )
+        return summaries[-1]
+
+    def record_lean_check(
+        self,
+        *,
+        call_id: str | None,
+        problem_uuid: str,
+        theorem_name: str,
+        iteration: int,
+        outcome: str,
+        success: bool,
+        feedback_type: str,
+        diagnostics: str,
+        duration_seconds: float,
+    ) -> str | None:
+        """Persist the verifier outcome following a proposer call."""
+
+        if not self.enabled or self.output_dir is None or not call_id:
+            return None
+        check_id = f"{call_id}:lean"
+        _append_jsonl(
+            self.output_dir / "lean_checks.jsonl",
+            {
+                "schema_version": 1,
+                "recorded_at": _now(),
+                "check_id": check_id,
+                "call_id": call_id,
+                "run_id": self.config.run_id,
+                "problem_uuid": problem_uuid,
+                "theorem_name": theorem_name,
+                "iteration": iteration,
+                "outcome": outcome,
+                "success": success,
+                "feedback_type": feedback_type,
+                "diagnostics": diagnostics,
+                "duration_seconds": round(duration_seconds, 6),
+            },
+        )
+        return check_id
+
+
+def _provider_reasoning(message: dict[str, Any]) -> tuple[str, str | None]:
+    for field_name in ("reasoning", "reasoning_content"):
+        value = message.get(field_name)
+        if isinstance(value, str) and value:
+            return value, field_name
+    return "", None
+
+
+def _entry_bytes(entry: Any) -> bytes:
+    if not isinstance(entry, dict):
+        raise ReasoningAlignmentError("logprob token entry is not a mapping")
+    raw_bytes = entry.get("bytes")
+    if isinstance(raw_bytes, list) and all(isinstance(item, int) for item in raw_bytes):
+        return bytes(raw_bytes)
+    token = entry.get("token")
+    if isinstance(token, str):
+        return token.encode("utf-8")
+    raise ReasoningAlignmentError("logprob token entry has neither bytes nor token text")
+
+
+def _token_entropy_metrics(
+    entry: dict[str, Any],
+    *,
+    vocabulary_size: int | None,
+) -> dict[str, float | int | None]:
+    alternatives: dict[tuple[Any, ...], float] = {}
+    sampled_key = _token_key(entry)
+    sampled_logprob = _finite_float(entry.get("logprob"))
+    if sampled_logprob is not None:
+        alternatives[sampled_key] = sampled_logprob
+    raw_top = entry.get("top_logprobs")
+    if isinstance(raw_top, list):
+        for item in raw_top:
+            if not isinstance(item, dict):
+                continue
+            logprob = _finite_float(item.get("logprob"))
+            if logprob is None:
+                continue
+            key = _token_key(item)
+            previous = alternatives.get(key)
+            if previous is None or logprob > previous:
+                alternatives[key] = logprob
+
+    probabilities = [math.exp(value) for value in alternatives.values()]
+    returned_mass_raw = sum(probabilities)
+    returned_mass = min(1.0, max(0.0, returned_mass_raw))
+    partial_entropy = -sum(value * math.log(value) for value in probabilities if value > 0)
+    normalized_entropy = None
+    if returned_mass_raw > 0:
+        normalized = [value / returned_mass_raw for value in probabilities]
+        normalized_entropy = -sum(value * math.log(value) for value in normalized if value > 0)
+    tail_mass = max(0.0, 1.0 - returned_mass)
+    lower_bound = partial_entropy + _entropy_term(tail_mass)
+    upper_bound = None
+    if vocabulary_size is not None:
+        remaining = vocabulary_size - len(alternatives)
+        if remaining < 0:
+            raise ValueError("vocabulary_size is smaller than returned alternative count")
+        upper_bound = (
+            partial_entropy
+            if tail_mass == 0
+            else partial_entropy - tail_mass * math.log(tail_mass / max(1, remaining))
+        )
+    return {
+        "alternative_count": len(alternatives),
+        "sampled_surprisal": -sampled_logprob if sampled_logprob is not None else None,
+        "returned_mass": returned_mass,
+        "returned_mass_raw": returned_mass_raw,
+        "partial_entropy": partial_entropy,
+        "normalized_topk_entropy": normalized_entropy,
+        "tail_mass": tail_mass,
+        "entropy_lower_bound": lower_bound,
+        "entropy_upper_bound": upper_bound,
+    }
+
+
+def _token_key(entry: dict[str, Any]) -> tuple[Any, ...]:
+    raw_bytes = entry.get("bytes")
+    if isinstance(raw_bytes, list) and all(isinstance(item, int) for item in raw_bytes):
+        return ("bytes", *raw_bytes)
+    return ("token", str(entry.get("token") or ""))
+
+
+def _entropy_term(probability: float) -> float:
+    return 0.0 if probability <= 0 else -probability * math.log(probability)
+
+
+def _aggregate_tokens(tokens: list[dict[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {"reasoning_token_count": len(tokens)}
+    for field_name in (
+        "sampled_surprisal",
+        "partial_entropy",
+        "normalized_topk_entropy",
+        "returned_mass",
+        "entropy_lower_bound",
+        "entropy_upper_bound",
+    ):
+        values = [
+            float(token[field_name])
+            for token in tokens
+            if isinstance(token.get(field_name), int | float)
+        ]
+        result[f"mean_{field_name}"] = statistics.fmean(values) if values else None
+        result[f"median_{field_name}"] = statistics.median(values) if values else None
+        result[f"max_{field_name}"] = max(values) if values else None
+    return result
+
+
+def _analysis_failure(status: str) -> dict[str, Any]:
+    return {
+        "alignment_status": status,
+        "tokens": [],
+        "aggregates": {},
+        "reasoning_token_count": 0,
+    }
+
+
+def _normalized_reasoning(response: Any) -> str:
+    additional = getattr(response, "additional_kwargs", {})
+    if isinstance(additional, dict):
+        for field_name in ("reasoning", "reasoning_content"):
+            value = additional.get(field_name)
+            if isinstance(value, str) and value:
+                return value
+    try:
+        blocks = response.content_blocks
+    except (AttributeError, TypeError, ValueError):
+        blocks = []
+    if isinstance(blocks, list):
+        values = [
+            str(block.get("reasoning") or block.get("text") or "")
+            for block in blocks
+            if isinstance(block, dict) and block.get("type") == "reasoning"
+        ]
+        return "\n\n".join(value for value in values if value)
+    return ""
+
+
+def _normalized_text(response: Any) -> str:
+    value = getattr(response, "text", "")
+    return value() if callable(value) else str(value or "")
+
+
+def _normalized_response_dump(response: Any) -> Any:
+    model_dump = getattr(response, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    return {"text": _normalized_text(response), "reasoning": _normalized_reasoning(response)}
+
+
+def _safe_headers(headers: httpx.Headers) -> dict[str, str]:
+    allowed = {"content-type", "content-length", "x-request-id", "request-id"}
+    return {key.lower(): value for key, value in headers.items() if key.lower() in allowed}
+
+
+def _load_json(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def _decoder_settings(request: Any) -> dict[str, Any]:
+    if not isinstance(request, dict):
+        return {}
+    return {
+        key: request.get(key)
+        for key in (
+            "temperature",
+            "top_p",
+            "top_k",
+            "logprobs",
+            "top_logprobs",
+            "max_tokens",
+            "max_completion_tokens",
+            "seed",
+            "stream",
+            "include_reasoning",
+        )
+        if key in request
+    }
+
+
+def _finite_float(value: Any) -> float | None:
+    if not isinstance(value, int | float):
+        return None
+    converted = float(value)
+    return converted if math.isfinite(converted) else None
+
+
+def _exchange_request_hash(exchange: RawHTTPExchange | None) -> str | None:
+    return _sha256(exchange.request_body_utf8) if exchange else None
+
+
+def _exchange_response_hash(exchange: RawHTTPExchange | None) -> str | None:
+    return _sha256(exchange.response_body_utf8) if exchange else None
+
+
+def _sha256(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    data = (json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
+    _append_bytes(path, data)
+
+
+def _append_gzip_jsonl_many(path: Path, payloads: list[dict[str, Any]]) -> None:
+    if not payloads:
+        return
+    lines = "".join(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n" for payload in payloads
+    ).encode("utf-8")
+    _append_bytes(path, gzip.compress(lines, mtime=0))
+
+
+def _append_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o640)
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            view = view[written:]
+    finally:
+        os.close(descriptor)

--- a/tests/unit/utils/test_llm_reasoning.py
+++ b/tests/unit/utils/test_llm_reasoning.py
@@ -1,0 +1,32 @@
+"""Tests for normalized reasoning extraction."""
+
+from langchain_core.messages import AIMessage
+
+from ax_prover.utils.llm import LLMClient, get_reasoning
+
+
+def test_get_reasoning_prefers_openai_reasoning_content() -> None:
+    response = AIMessage(
+        content="final",
+        additional_kwargs={"reasoning_content": "private trace"},
+    )
+
+    assert get_reasoning(response) == "private trace"
+
+
+def test_get_reasoning_supports_content_blocks() -> None:
+    response = AIMessage(
+        content=[
+            {"type": "reasoning", "reasoning": "first"},
+            {"type": "text", "text": "final"},
+        ]
+    )
+
+    assert get_reasoning(response) == "first"
+
+
+def test_llm_client_normalizes_none_profile() -> None:
+    client = LLMClient.__new__(LLMClient)
+    client._base_llm = type("ModelWithNoneProfile", (), {"profile": None})()
+
+    assert client.profile == {}

--- a/tests/unit/utils/test_llm_structured_output.py
+++ b/tests/unit/utils/test_llm_structured_output.py
@@ -1,0 +1,227 @@
+"""Regression tests for OpenAI-compatible manual structured output."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+
+from ax_prover.config import LLMConfig, StructuredOutputMode
+from ax_prover.models.files import Location
+from ax_prover.models.messages import StructuredOutputParsingFailedFeedback
+from ax_prover.models.proving import ProverAgentState, ProverResult, TargetItem
+from ax_prover.prover.agent import ProverAgent
+from ax_prover.utils.llm import LLMClient, _openai_structured_kwargs, agentic_loop
+
+
+def test_native_pydantic_remains_the_default_openai_format() -> None:
+    assert LLMConfig(model="openai:test").structured_output_mode == "native_pydantic"
+    assert _openai_structured_kwargs(ProverResult) == {"response_format": ProverResult}
+
+
+def test_manual_openai_format_is_strict_json_schema() -> None:
+    response_format = _openai_structured_kwargs(
+        ProverResult, StructuredOutputMode.JSON_SCHEMA_MANUAL
+    )["response_format"]
+
+    assert response_format["type"] == "json_schema"
+    assert response_format["json_schema"]["name"] == "ProverResult"
+    assert response_format["json_schema"]["strict"] is True
+    schema = response_format["json_schema"]["schema"]
+    assert schema["required"] == ["imports", "opens", "updated_theorem"]
+    assert schema["additionalProperties"] is False
+
+
+def test_manual_mode_rejects_non_openai_provider() -> None:
+    client = LLMClient.__new__(LLMClient)
+    client._base_llm = ChatAnthropic(
+        model="claude-sonnet-4-5-20250929",
+        api_key="test-key",
+    )
+    client._structured_output_mode = StructuredOutputMode.JSON_SCHEMA_MANUAL
+
+    with pytest.raises(ValueError, match="requires an OpenAI-compatible"):
+        client._structured_output_bind_kwargs(ProverResult)
+
+
+def test_content_with_tool_call_survives_until_tool_execution() -> None:
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        requests.append(payload)
+        if len(requests) == 1:
+            message = {
+                "role": "assistant",
+                "content": "I will search for the relevant Lean declaration first.",
+                "tool_calls": [
+                    {
+                        "id": "call-search-1",
+                        "type": "function",
+                        "function": {
+                            "name": "search_lean_test",
+                            "arguments": '{"query":"Nat.add_zero"}',
+                        },
+                    }
+                ],
+            }
+            finish_reason = "tool_calls"
+        else:
+            message = {
+                "role": "assistant",
+                "content": json.dumps(
+                    {
+                        "imports": [],
+                        "opens": [],
+                        "updated_theorem": "theorem add_zero_test (n : Nat) : n + 0 = n := by simp",
+                    }
+                ),
+            }
+            finish_reason = "stop"
+        return httpx.Response(
+            200,
+            json={
+                "id": f"chatcmpl-{len(requests)}",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "local-test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": finish_reason,
+                        "logprobs": None,
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    async def run() -> None:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            model = ChatOpenAI(
+                model="local-test-model",
+                api_key="test-key",
+                base_url="http://local.test/v1",
+                http_async_client=http_client,
+                max_retries=0,
+            )
+            client = LLMClient.__new__(LLMClient)
+            client._base_llm = model
+            client._retry_config = {}
+            client._structured_output_mode = StructuredOutputMode.JSON_SCHEMA_MANUAL
+            client._trace_http_client = None
+
+            @tool
+            def search_lean_test(query: str) -> str:
+                """Search for a Lean declaration."""
+                assert query == "Nat.add_zero"
+                return "#check Nat.add_zero"
+
+            class TestToolNode:
+                def __init__(self, tools):
+                    self.tools = {available.name: available for available in tools}
+
+                async def ainvoke(self, state):
+                    call = state["messages"][-1].tool_calls[0]
+                    result = self.tools[call["name"]].invoke(call["args"])
+                    return {
+                        "messages": [
+                            ToolMessage(
+                                content=result,
+                                name=call["name"],
+                                tool_call_id=call["id"],
+                            )
+                        ]
+                    }
+
+            with patch("ax_prover.utils.llm.ToolNode", TestToolNode):
+                response = await agentic_loop(
+                    client,
+                    [HumanMessage(content="Prove add_zero_test")],
+                    tools=[search_lean_test],
+                    output_schema=ProverResult,
+                    max_tool_iterations=1,
+                )
+
+        result = ProverResult.model_validate_json(response.text)
+        assert result.updated_theorem.startswith("theorem add_zero_test")
+
+    asyncio.run(run())
+
+    assert len(requests) == 2
+    assert requests[0]["response_format"]["type"] == "json_schema"
+    second_messages = requests[1]["messages"]
+    assistant = next(message for message in second_messages if message["role"] == "assistant")
+    assert assistant["content"].startswith("I will search")
+    assert assistant["tool_calls"][0]["function"]["name"] == "search_lean_test"
+    tool_result = next(message for message in second_messages if message["role"] == "tool")
+    assert tool_result["content"] == "#check Nat.add_zero"
+
+
+def test_invalid_final_json_becomes_graph_feedback_not_transport_error(tmp_path) -> None:
+    source = tmp_path / "Test" / "Module.lean"
+    source.parent.mkdir()
+    source.write_text("theorem thm : True := by\n  sorry\n", encoding="utf-8")
+    with patch.object(ProverAgent, "__init__", lambda self, *args, **kwargs: None):
+        agent = ProverAgent.__new__(ProverAgent)
+    agent.logger = MagicMock()
+    agent.config = SimpleNamespace(
+        max_iterations=50,
+        user_comments=None,
+        reasoning_trace=SimpleNamespace(
+            run_id="run",
+            problem_uuid="problem",
+        ),
+    )
+    agent.runtime = SimpleNamespace(
+        base_folder=str(tmp_path),
+        config=SimpleNamespace(max_tool_calling_iterations=1),
+    )
+    agent.llm_client = MagicMock()
+    agent.proposer_tools = []
+    agent._trace_call_index = 0
+    agent.reasoning_trace_writer = MagicMock()
+    agent.reasoning_trace_writer.record_proposer.return_value = {
+        "call_id": "run:problem:proposer:1:1",
+        "alignment_status": "aligned",
+        "reasoning": "attempt",
+    }
+    state = ProverAgentState(
+        item=TargetItem(
+            location=Location(name="thm", module_path="Test.Module"),
+            original_source=source.read_text(encoding="utf-8"),
+        )
+    )
+
+    with patch(
+        "ax_prover.prover.agent.agentic_loop",
+        new=AsyncMock(return_value=AIMessage(content="not valid final JSON")),
+    ):
+        update = asyncio.run(agent._proposer_node(state, {}))
+
+    feedback = update["messages"][0]
+    assert isinstance(feedback, StructuredOutputParsingFailedFeedback)
+    agent.reasoning_trace_writer.record_transport_failure.assert_not_called()
+    agent.reasoning_trace_writer.record_lean_check.assert_called_once_with(
+        call_id="run:problem:proposer:1:1",
+        problem_uuid="problem",
+        theorem_name="thm",
+        iteration=1,
+        outcome="not_run_structured_output_parse_failed",
+        success=False,
+        feedback_type="structured_output_parsing_failed",
+        diagnostics=feedback.error_message,
+        duration_seconds=0.0,
+    )

--- a/tests/unit/utils/test_reasoning_trace.py
+++ b/tests/unit/utils/test_reasoning_trace.py
@@ -1,0 +1,601 @@
+"""Tests for lossless reasoning alignment and entropy calculations."""
+
+import gzip
+import json
+import math
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from ax_prover.config import ReasoningTraceConfig
+from ax_prover.utils.reasoning_trace import (
+    LLMTraceCapture,
+    LLMTraceContext,
+    RawHTTPExchange,
+    ReasoningAlignmentError,
+    ReasoningTraceWriter,
+    analyze_provider_payload,
+)
+
+
+def _entry(token: str, probability: float, alternatives: list[tuple[str, float]]) -> dict:
+    return {
+        "token": token,
+        "bytes": list(token.encode()),
+        "logprob": math.log(probability),
+        "top_logprobs": [
+            {
+                "token": alternative,
+                "bytes": list(alternative.encode()),
+                "logprob": math.log(alternative_probability),
+            }
+            for alternative, alternative_probability in alternatives
+        ],
+    }
+
+
+def _payload() -> dict:
+    return {
+        "id": "completion-1",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "reasoning_content": "think",
+                    "content": '{"updated_theorem":"theorem t : True := by trivial"}',
+                },
+                "logprobs": {
+                    "content": [
+                        _entry("think", 0.5, [("think", 0.5), ("prove", 0.25)]),
+                        _entry(
+                            '{"updated_theorem":"theorem t : True := by trivial"}',
+                            0.75,
+                            [
+                                (
+                                    '{"updated_theorem":"theorem t : True := by trivial"}',
+                                    0.75,
+                                ),
+                                ("[]", 0.1),
+                            ],
+                        ),
+                    ]
+                },
+            }
+        ],
+        "usage": {"completion_tokens": 2},
+    }
+
+
+def test_aligns_only_reasoning_tokens_and_computes_entropy() -> None:
+    analysis = analyze_provider_payload(_payload(), vocabulary_size=4)
+
+    assert analysis["alignment_status"] == "aligned"
+    assert analysis["reasoning_token_count"] == 1
+    assert analysis["reasoning_token_start"] == 0
+    assert analysis["reasoning_token_end"] == 1
+    assert analysis["final_alignment_status"] == "aligned"
+    assert analysis["final_token_count"] == 1
+    token = analysis["tokens"][0]
+    assert token["alternative_count"] == 2  # sampled token is de-duplicated
+    assert token["sampled_surprisal"] == pytest.approx(-math.log(0.5))
+    assert token["returned_mass"] == pytest.approx(0.75)
+    assert token["partial_entropy"] == pytest.approx(-(0.5 * math.log(0.5) + 0.25 * math.log(0.25)))
+    assert token["entropy_lower_bound"] == pytest.approx(
+        token["partial_entropy"] - 0.25 * math.log(0.25)
+    )
+    assert token["entropy_upper_bound"] == pytest.approx(
+        token["partial_entropy"] - 0.25 * math.log(0.25 / 2)
+    )
+
+
+def test_zero_tail_has_equal_entropy_bounds() -> None:
+    payload = _payload()
+    payload["choices"][0]["logprobs"]["content"][0] = _entry(
+        "think", 0.5, [("think", 0.5), ("prove", 0.5)]
+    )
+
+    token = analyze_provider_payload(payload, vocabulary_size=2)["tokens"][0]
+
+    assert token["tail_mass"] == pytest.approx(0.0)
+    assert token["entropy_lower_bound"] == pytest.approx(math.log(2))
+    assert token["entropy_upper_bound"] == pytest.approx(math.log(2))
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        (lambda payload: payload["choices"][0].pop("logprobs"), "logprobs_missing"),
+        (
+            lambda payload: payload["choices"][0]["message"].update(reasoning_content="absent"),
+            "reasoning_not_found_in_logprob_tokens",
+        ),
+    ],
+)
+def test_reports_missing_alignment(mutate, expected: str) -> None:
+    payload = _payload()
+    mutate(payload)
+
+    assert analyze_provider_payload(payload, vocabulary_size=None)["alignment_status"] == expected
+
+
+def test_aligns_reasoning_between_special_tokens() -> None:
+    payload = _payload()
+    entries = payload["choices"][0]["logprobs"]["content"]
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("<think>", 0.9, [("<think>", 0.9)]),
+        entries[0],
+        _entry("</think>", 0.9, [("</think>", 0.9)]),
+        entries[1],
+    ]
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=151936)
+
+    assert analysis["alignment_status"] == "aligned"
+    assert analysis["reasoning_token_start"] == 1
+    assert analysis["reasoning_token_end"] == 2
+    assert analysis["final_token_start"] == 3
+    assert analysis["alignment_basis"] == "qwen3_delimiter_token_span"
+
+
+def test_aligns_unclosed_reasoning_after_length_stop() -> None:
+    payload = _payload()
+    payload["choices"][0]["finish_reason"] = "length"
+    payload["choices"][0]["message"] = {"content": "<think>truncated thought"}
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("<think>", 0.9, [("<think>", 0.9)]),
+        _entry("truncated thought", 0.8, [("truncated thought", 0.8)]),
+    ]
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=151936)
+
+    assert analysis["alignment_status"] == "aligned"
+    assert analysis["reasoning_field"] == "content_unclosed_think_truncated"
+    assert analysis["reasoning"] == "truncated thought"
+    assert analysis["reasoning_token_count"] == 1
+    assert analysis["final_content"] == ""
+    assert analysis["final_alignment_status"] == "empty"
+    assert analysis["finish_reason"] == "length"
+
+
+def test_truncated_region_uses_token_boundaries_when_provider_bytes_replace_unicode() -> None:
+    payload = _payload()
+    payload["choices"][0]["finish_reason"] = "length"
+    payload["choices"][0]["message"] = {"content": "<think>∑ thought"}
+    unicode_entry = _entry("∑ thought", 0.8, [("∑ thought", 0.8)])
+    unicode_entry["bytes"] = [239, 191, 189, 32, 116, 104, 111, 117, 103, 104, 116]
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("<think>", 0.9, [("<think>", 0.9)]),
+        unicode_entry,
+    ]
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=151936)
+
+    assert analysis["alignment_status"] == "aligned"
+    assert analysis["alignment_basis"] == "opening_think_delimiter_to_length_stop"
+    assert analysis["reasoning_token_count"] == 1
+    assert analysis["reasoning_decode_matches_provider"] is False
+
+
+def test_closed_delimiters_align_unicode_despite_replacement_provider_bytes() -> None:
+    payload = _payload()
+    payload["choices"][0]["message"]["reasoning_content"] = "∑ thought"
+    payload["choices"][0]["message"]["content"] = '{"updated_theorem":"theorem ∑"}'
+    reasoning_entry = _entry("∑ thought", 0.8, [("∑ thought", 0.8)])
+    reasoning_entry["bytes"] = [239, 191, 189, 32, 116, 104, 111, 117, 103, 104, 116]
+    final_entry = _entry('{"updated_theorem":"theorem ∑"}', 0.8, [])
+    final_entry["bytes"] = list('{"updated_theorem":"theorem �"}'.encode())
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("<think>", 0.9, [("<think>", 0.9)]),
+        reasoning_entry,
+        _entry("</think>", 0.9, [("</think>", 0.9)]),
+        final_entry,
+        _entry("<|im_end|>", 0.9, [("<|im_end|>", 0.9)]),
+    ]
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=151936)
+
+    assert analysis["alignment_status"] == "aligned"
+    assert analysis["alignment_basis"] == "qwen3_delimiter_token_span"
+    assert analysis["reasoning_token_count"] == 1
+    assert analysis["reasoning_decode_matches_provider"] is False
+    assert analysis["final_alignment_status"] == "aligned"
+    assert analysis["final_token_count"] == 1
+    assert analysis["final_decode_matches_provider"] is False
+
+
+def test_first_closing_delimiter_aligns_reasoning_when_later_closings_repeat() -> None:
+    payload = _payload()
+    payload["choices"][0]["message"]["reasoning_content"] = "∑ thought"
+    payload["choices"][0]["message"]["content"] = "finalfinal"
+    reasoning_entry = _entry("∑ thought", 0.8, [("∑ thought", 0.8)])
+    reasoning_entry["bytes"] = [239, 191, 189, 32, 116, 104, 111, 117, 103, 104, 116]
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("<think>", 0.9, [("<think>", 0.9)]),
+        reasoning_entry,
+        _entry("</think>", 0.9, [("</think>", 0.9)]),
+        _entry("final", 0.8, [("final", 0.8)]),
+        _entry("</think>", 0.9, [("</think>", 0.9)]),
+        _entry("final", 0.8, [("final", 0.8)]),
+        _entry("<|im_end|>", 0.9, [("<|im_end|>", 0.9)]),
+    ]
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=151936)
+
+    assert analysis["alignment_status"] == "aligned"
+    assert analysis["alignment_basis"] == "qwen3_first_closing_delimiter_token_span"
+    assert analysis["reasoning_token_start"] == 1
+    assert analysis["reasoning_token_end"] == 2
+    assert analysis["reasoning_token_count"] == 1
+    assert analysis["reasoning_decode_matches_provider"] is False
+
+
+def test_rejects_reasoning_boundary_that_splits_a_token() -> None:
+    payload = _payload()
+    payload["choices"][0]["logprobs"]["content"][0] = _entry(
+        "prefixthink", 0.5, [("prefixthink", 0.5)]
+    )
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=None)
+
+    assert analysis["alignment_status"] == "reasoning_boundary_splits_token"
+
+
+def test_rejects_ambiguous_reasoning_alignment() -> None:
+    payload = _payload()
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("think", 0.5, [("think", 0.5)]),
+        _entry("think", 0.5, [("think", 0.5)]),
+        payload["choices"][0]["logprobs"]["content"][1],
+    ]
+
+    analysis = analyze_provider_payload(payload, vocabulary_size=None)
+
+    assert analysis["alignment_status"] == "reasoning_alignment_ambiguous"
+
+
+def test_writer_persists_lossless_call_tokens_and_lean_link(tmp_path) -> None:
+    context = LLMTraceContext(
+        run_id="run-1",
+        problem_uuid="problem-1",
+        theorem_name="t",
+        iteration=1,
+        call_index=1,
+        role="proposer",
+    )
+    payload = _payload()
+    capture = LLMTraceCapture(
+        context=context,
+        exchanges=[
+            RawHTTPExchange(
+                captured_at="2026-08-20T00:00:00+00:00",
+                method="POST",
+                url="http://127.0.0.1:8000/v1/chat/completions",
+                status_code=200,
+                request_headers={"content-type": "application/json"},
+                response_headers={"content-type": "application/json"},
+                request_body_utf8=json.dumps({"messages": [{"role": "user", "content": "p"}]}),
+                response_body_utf8=json.dumps(payload),
+            )
+        ],
+    )
+    writer = ReasoningTraceWriter(
+        ReasoningTraceConfig(
+            enabled=True,
+            output_dir=str(tmp_path),
+            run_id="run-1",
+            problem_uuid="problem-1",
+            vocabulary_size=4,
+        )
+    )
+
+    summary = writer.record_proposer(
+        capture=capture,
+        normalized_response=AIMessage(
+            content=payload["choices"][0]["message"]["content"],
+            additional_kwargs={"reasoning_content": "think"},
+        ),
+    )
+    check_id = writer.record_lean_check(
+        call_id=summary["call_id"],
+        problem_uuid="problem-1",
+        theorem_name="t",
+        iteration=1,
+        outcome="build_success",
+        success=True,
+        feedback_type="build_success",
+        diagnostics="",
+        duration_seconds=0.25,
+    )
+
+    call = json.loads((tmp_path / "llm_calls.jsonl").read_text().splitlines()[0])
+    with gzip.open(tmp_path / "reasoning_tokens.jsonl.gz", "rt") as handle:
+        token = json.loads(handle.readline())
+    with gzip.open(tmp_path / "final_tokens.jsonl.gz", "rt") as handle:
+        final_token = json.loads(handle.readline())
+    check = json.loads((tmp_path / "lean_checks.jsonl").read_text().splitlines()[0])
+    assert call["provider_response"] == payload
+    assert call["reasoning"] == "think"
+    assert token["call_id"] == call["call_id"]
+    assert final_token["region"] == "structured_final_output"
+    assert final_token["call_id"] == call["call_id"]
+    assert check["call_id"] == token["call_id"]
+    assert check_id == f"{call['call_id']}:lean"
+
+
+def test_multiple_problem_writers_append_readable_trace_members(tmp_path) -> None:
+    for index in range(1, 5):
+        problem_uuid = f"problem-{index}"
+        context = LLMTraceContext("run", problem_uuid, f"t{index}", 1, 1, "proposer")
+        payload = _payload()
+        capture = LLMTraceCapture(
+            context=context,
+            exchanges=[
+                RawHTTPExchange(
+                    captured_at="now",
+                    method="POST",
+                    url="http://local",
+                    status_code=200,
+                    request_headers={},
+                    response_headers={},
+                    request_body_utf8="{}",
+                    response_body_utf8=json.dumps(payload),
+                )
+            ],
+        )
+        writer = ReasoningTraceWriter(
+            ReasoningTraceConfig(
+                enabled=True,
+                output_dir=str(tmp_path),
+                run_id="run",
+                problem_uuid=problem_uuid,
+                vocabulary_size=4,
+            )
+        )
+        writer.record_proposer(
+            capture=capture,
+            normalized_response=AIMessage(
+                content=payload["choices"][0]["message"]["content"],
+                additional_kwargs={"reasoning_content": "think"},
+            ),
+        )
+
+    calls = [json.loads(line) for line in (tmp_path / "llm_calls.jsonl").read_text().splitlines()]
+    with gzip.open(tmp_path / "reasoning_tokens.jsonl.gz", "rt") as handle:
+        reasoning_tokens = [json.loads(line) for line in handle]
+    with gzip.open(tmp_path / "final_tokens.jsonl.gz", "rt") as handle:
+        final_tokens = [json.loads(line) for line in handle]
+
+    expected = {f"problem-{index}" for index in range(1, 5)}
+    assert {call["problem_uuid"] for call in calls} == expected
+    assert {token["problem_uuid"] for token in reasoning_tokens} == expected
+    assert {token["problem_uuid"] for token in final_tokens} == expected
+
+
+def test_writer_labels_tool_continuation_as_a_separate_model_call(tmp_path) -> None:
+    context = LLMTraceContext("run", "problem", "t", 1, 1, "proposer")
+    exchanges = []
+    for index in range(2):
+        payload = _payload()
+        payload["id"] = f"completion-{index}"
+        exchanges.append(
+            RawHTTPExchange(
+                captured_at="now",
+                method="POST",
+                url="http://local",
+                status_code=200,
+                request_headers={},
+                response_headers={},
+                request_body_utf8=json.dumps({"messages": []}),
+                response_body_utf8=json.dumps(payload),
+            )
+        )
+    writer = ReasoningTraceWriter(
+        ReasoningTraceConfig(
+            enabled=True,
+            output_dir=str(tmp_path),
+            vocabulary_size=4,
+        )
+    )
+
+    summary = writer.record_proposer(
+        capture=LLMTraceCapture(context=context, exchanges=exchanges),
+        normalized_response=AIMessage(content="final"),
+    )
+
+    calls = [
+        json.loads(line)
+        for line in (tmp_path / "llm_calls.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [call["role"] for call in calls] == ["proposer", "tool_continuation"]
+    assert calls[1]["parent_call_id"] == context.call_id
+    assert summary["call_id"] == f"{context.call_id}:tool:1"
+
+
+def test_writer_fails_closed_after_recording_unaligned_call(tmp_path) -> None:
+    context = LLMTraceContext("run", "problem", "t", 1, 1, "proposer")
+    payload = _payload()
+    payload["choices"][0].pop("logprobs")
+    capture = LLMTraceCapture(
+        context=context,
+        exchanges=[
+            RawHTTPExchange(
+                captured_at="now",
+                method="POST",
+                url="http://local",
+                status_code=200,
+                request_headers={},
+                response_headers={},
+                request_body_utf8="{}",
+                response_body_utf8=json.dumps(payload),
+            )
+        ],
+    )
+    writer = ReasoningTraceWriter(ReasoningTraceConfig(enabled=True, output_dir=str(tmp_path)))
+
+    with pytest.raises(ReasoningAlignmentError, match="logprobs_missing"):
+        writer.record_proposer(capture=capture, normalized_response=AIMessage(content="{}"))
+
+    record = json.loads((tmp_path / "llm_calls.jsonl").read_text())
+    assert record["alignment_status"] == "logprobs_missing"
+
+
+def test_writer_preserves_retry_exchanges_and_parser_failure_link(tmp_path) -> None:
+    context = LLMTraceContext("run", "problem", "t", 1, 1, "proposer")
+    payload = _payload()
+    capture = LLMTraceCapture(
+        context=context,
+        exchanges=[
+            RawHTTPExchange(
+                captured_at="first",
+                method="POST",
+                url="http://local",
+                status_code=500,
+                request_headers={},
+                response_headers={},
+                request_body_utf8="{}",
+                response_body_utf8='{ "error": "retry" }',
+            ),
+            RawHTTPExchange(
+                captured_at="second",
+                method="POST",
+                url="http://local",
+                status_code=200,
+                request_headers={},
+                response_headers={},
+                request_body_utf8="{}",
+                response_body_utf8=json.dumps(payload),
+            ),
+        ],
+    )
+    writer = ReasoningTraceWriter(
+        ReasoningTraceConfig(enabled=True, output_dir=str(tmp_path), vocabulary_size=151936)
+    )
+
+    summary = writer.record_proposer(
+        capture=capture,
+        normalized_response=AIMessage(content="malformed final response"),
+    )
+    writer.record_lean_check(
+        call_id=summary["call_id"],
+        problem_uuid="problem",
+        theorem_name="t",
+        iteration=1,
+        outcome="not_run_structured_output_parse_failed",
+        success=False,
+        feedback_type="structured_output_parsing_failed",
+        diagnostics="invalid JSON",
+        duration_seconds=0,
+    )
+
+    call = json.loads((tmp_path / "llm_calls.jsonl").read_text())
+    check = json.loads((tmp_path / "lean_checks.jsonl").read_text())
+    assert len(call["raw_http_exchanges"]) == 2
+    assert call["provider_response"] == payload
+    assert check["call_id"] == call["call_id"]
+    assert check["outcome"] == "not_run_structured_output_parse_failed"
+
+
+def test_writer_recovers_truncated_reasoning_when_client_normalization_fails(tmp_path) -> None:
+    context = LLMTraceContext("run", "problem", "t", 1, 1, "proposer")
+    payload = _payload()
+    payload["choices"][0]["finish_reason"] = "length"
+    payload["choices"][0]["message"] = {"content": "<think>truncated thought"}
+    payload["choices"][0]["logprobs"]["content"] = [
+        _entry("<think>", 0.9, [("<think>", 0.9)]),
+        _entry("truncated thought", 0.8, [("truncated thought", 0.8)]),
+    ]
+    capture = LLMTraceCapture(
+        context=context,
+        exchanges=[
+            RawHTTPExchange(
+                captured_at="now",
+                method="POST",
+                url="http://local",
+                status_code=200,
+                request_headers={},
+                response_headers={},
+                request_body_utf8="{}",
+                response_body_utf8=json.dumps(payload),
+            )
+        ],
+    )
+    writer = ReasoningTraceWriter(
+        ReasoningTraceConfig(enabled=True, output_dir=str(tmp_path), vocabulary_size=151936)
+    )
+
+    summary = writer.record_transport_failure(capture=capture, error=RuntimeError("length"))
+
+    call = json.loads((tmp_path / "llm_calls.jsonl").read_text())
+    with gzip.open(tmp_path / "reasoning_tokens.jsonl.gz", "rt") as handle:
+        token = json.loads(handle.readline())
+    assert summary["alignment_status"] == "aligned"
+    assert summary["finish_reason"] == "length"
+    assert call["reasoning_token_count"] == 1
+    assert call["error_type"] == "RuntimeError"
+    assert token["token"] == "truncated thought"
+
+
+def test_writer_normalizes_every_successful_attempt_before_terminal_failure(tmp_path) -> None:
+    context = LLMTraceContext("run", "problem", "t", 1, 1, "proposer")
+    exchanges = []
+    for index in range(3):
+        payload = _payload()
+        payload["id"] = f"completion-{index}"
+        payload["choices"][0]["message"]["reasoning_content"] = "think"
+        payload["choices"][0]["logprobs"]["content"][0] = _entry(
+            "think", 0.5, [("think", 0.5), ("prove", 0.25)]
+        )
+        if index:
+            payload["choices"][0]["finish_reason"] = "length"
+            payload["choices"][0]["message"]["content"] = ""
+            payload["choices"][0]["logprobs"]["content"] = [
+                payload["choices"][0]["logprobs"]["content"][0]
+            ]
+        exchanges.append(
+            RawHTTPExchange(
+                captured_at=f"attempt-{index}",
+                method="POST",
+                url="http://local",
+                status_code=200,
+                request_headers={},
+                response_headers={},
+                request_body_utf8=json.dumps({"messages": []}),
+                response_body_utf8=json.dumps(payload),
+            )
+        )
+    writer = ReasoningTraceWriter(
+        ReasoningTraceConfig(enabled=True, output_dir=str(tmp_path), vocabulary_size=4)
+    )
+
+    summary = writer.record_transport_failure(
+        capture=LLMTraceCapture(context=context, exchanges=exchanges),
+        error=RuntimeError("length"),
+    )
+
+    calls = [
+        json.loads(line)
+        for line in (tmp_path / "llm_calls.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    with gzip.open(tmp_path / "reasoning_tokens.jsonl.gz", "rt") as handle:
+        tokens = [json.loads(line) for line in handle]
+    assert [call["call_id"] for call in calls] == [
+        context.call_id,
+        f"{context.call_id}:tool:1",
+        f"{context.call_id}:tool:2",
+    ]
+    assert [call["role"] for call in calls] == [
+        "proposer",
+        "tool_continuation",
+        "tool_continuation",
+    ]
+    assert [call["finish_reason"] for call in calls] == ["stop", "length", "length"]
+    assert [token["call_id"] for token in tokens] == [
+        context.call_id,
+        f"{context.call_id}:tool:1",
+        f"{context.call_id}:tool:2",
+    ]
+    assert "error_type" not in calls[0]
+    assert "error_type" not in calls[1]
+    assert calls[2]["error_type"] == "RuntimeError"
+    assert summary["call_id"] == f"{context.call_id}:tool:2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core prover LLM invocation and can fail runs when alignment is required; default configs keep tracing off, but misconfiguration or OpenAI-only raw capture could affect experiment workflows.
> 
> **Overview**
> Adds an **optional reasoning-trace pipeline** for local OpenAI-compatible (vLLM) runs: raw HTTP capture, alignment of chain-of-thought to logprob tokens, per-token top-k entropy metrics, and on-disk artifacts (`llm_calls.jsonl`, compressed token streams, `lean_checks.jsonl`) keyed by run/problem/call. **`ProverConfig`** gains `max_input_tokens`, `reasoning_trace`, and LLM **`structured_output_mode`** (`native_pydantic` vs `json_schema_manual` for tool+JSON flows).
> 
> **`ProverAgent`** wires tracing through proposer, memory, reviewer, and summarizer; proposals carry **`trace_call_id`** for Lean outcomes; with **`require_alignment: true`**, misaligned traces can abort via **`ReasoningAlignmentError`** (paper configs often set this false so tracing stays observational). **`LLMClient`** enables httpx response hooks when tracing is on and improves reasoning extraction from provider fields.
> 
> Several **Kimina/Qwen paper YAML profiles** turn on logprobs, `include_reasoning`, and tracing for entropy experiments. Unit tests cover alignment edge cases, writers, manual JSON schema mode, and agent failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b45dc7b5bae89d0f7c3f900e63bc985bd416a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->