### PR TITLE
Fail fast on permanent LLM errors instead of retrying for hours

### DIFF
--- a/src/ax_prover/config.py
+++ b/src/ax_prover/config.py
@@ -34,9 +34,10 @@ class LogLevel(StrEnum):
     CRITICAL = "CRITICAL"
 
 
+# Only transient failures (rate limits, server errors, connection loss) are retried;
+# permanent errors such as bad request parameters fail immediately. See LLMClient.
 DEFAULT_LLM_RETRY_CONFIG = {
     "stop_after_attempt": 10000,  # 10k attempts at 3s is about 8h 20min.
-    "wait_exponential_jitter": True,
     "exponential_jitter_params": {
         "initial": 0.5,
         "max": 3,

--- a/src/ax_prover/utils/llm.py
+++ b/src/ax_prover/utils/llm.py
@@ -1,7 +1,10 @@
 """LLM factory functions."""
 
+import logging
 import os
 
+import anthropic
+import openai
 from anthropic import transform_schema
 from langchain.chat_models import init_chat_model
 from langchain_anthropic import ChatAnthropic
@@ -14,8 +17,17 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import ToolNode
 from pydantic import BaseModel
+from tenacity import (
+    AsyncRetrying,
+    before_sleep_log,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from ..config import LLMConfig
+
+logger = logging.getLogger(__name__)
 
 _PROVIDER_API_KEY_ENV = {
     "anthropic": "ANTHROPIC_API_KEY",
@@ -89,6 +101,27 @@ def get_reasoning(response: AIMessage) -> str:
     return reasoning
 
 
+_CONNECTION_ERRORS = (anthropic.APIConnectionError, openai.APIConnectionError)
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """Whether a failed LLM call is worth retrying.
+
+    Rate limits, server errors and connection failures are transient. Anything else --
+    bad request parameters, auth failures, client-side validation -- is permanent, and
+    retrying it only hides the error behind hours of silent backoff.
+    """
+    if isinstance(exc, _CONNECTION_ERRORS):
+        return True
+
+    # Provider SDKs expose the HTTP status as `status_code` (anthropic, openai) or `code` (google)
+    status = getattr(exc, "status_code", None) or getattr(exc, "code", None)
+    if not isinstance(status, int):
+        return False
+
+    return status == 429 or status >= 500
+
+
 class LLMClient:
     """Dynamically create a Runnable to invoke LLMs with structured output, tool calling and retry.
 
@@ -133,20 +166,32 @@ class LLMClient:
     ) -> AIMessage:
         """Invoke with optional tools, structured output, and retry."""
         effective_retry = retry_config or self._retry_config
-        runnable = self._get_runnable(
-            tools=tools, output_schema=output_schema, retry_config=effective_retry
-        )
-        return await runnable.ainvoke(messages)
+        runnable = self._get_runnable(tools=tools, output_schema=output_schema)
+
+        if not effective_retry:
+            return await runnable.ainvoke(messages)
+
+        jitter_params = effective_retry.get("exponential_jitter_params", {})
+        async for attempt in AsyncRetrying(
+            retry=retry_if_exception(_is_transient_error),
+            stop=stop_after_attempt(effective_retry["stop_after_attempt"]),
+            wait=wait_exponential_jitter(**jitter_params),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        ):
+            with attempt:
+                return await runnable.ainvoke(messages)
+
+        raise AssertionError("unreachable: AsyncRetrying always returns or raises")
 
     def _get_runnable(
         self,
         tools: list[BaseTool] | None = None,
         output_schema: type[BaseModel] | None = None,
-        retry_config: dict | None = None,
     ) -> Runnable[LanguageModelInput, AIMessage]:
-        """Build a retryable Runnable that always returns AIMessage.
+        """Build a Runnable that always returns AIMessage.
 
-        Layers are applied in order: bind_tools → bind structured output → with_retry.
+        Layers are applied in order: bind_tools → bind structured output.
         """
         model: Runnable = self._base_llm
 
@@ -158,9 +203,6 @@ class LLMClient:
 
         if output_schema:
             model = model.bind(**self._structured_output_bind_kwargs(output_schema))
-
-        if retry_config:
-            model = model.with_retry(**retry_config)
 
         return model
 
@@ -175,8 +217,7 @@ class LLMClient:
         # LOOK AT WHAT IT NEED TO DO C'MONNNNN
 
         if isinstance(self._base_llm, ChatAnthropic):
-            model_name = getattr(self._base_llm, "model", "")  # Need to check 4.5 or 4.6+
-            return _anthropic_structured_kwargs(model_name, schema)
+            return _anthropic_structured_kwargs(schema)
 
         if isinstance(self._base_llm, ChatGoogleGenerativeAI):
             return _google_structured_kwargs(schema.model_json_schema())
@@ -189,20 +230,16 @@ class LLMClient:
         )
 
 
-def _anthropic_structured_kwargs(model_name: str, schema: type[BaseModel]) -> dict:
-    json_schema = schema.model_json_schema()
-    json_schema = transform_schema(json_schema)
+def _anthropic_structured_kwargs(schema: type[BaseModel]) -> dict:
+    """Constrain output to a JSON schema.
 
-    is_46 = "4-6" in model_name or "4.6" in model_name
+    `output_config.format` is the canonical parameter and is accepted by every Claude
+    model we use. The older `output_format` is deprecated and is removed in
+    langchain-anthropic 2.0.
+    """
+    json_schema = transform_schema(schema.model_json_schema())
 
-    schema_payload = {"type": "json_schema", "schema": json_schema}
-
-    if is_46:
-        # Claude 4.6+: output_config.format (output_format is deprecated)
-        return {"output_config": {"format": schema_payload}}
-    else:
-        # Claude 4.5 and earlier: output_format
-        return {"output_format": schema_payload}
+    return {"output_config": {"format": {"type": "json_schema", "schema": json_schema}}}
 
 
 def _google_structured_kwargs(schema: type[BaseModel]) -> dict:

--- a/tests/unit/utils/test_llm.py
+++ b/tests/unit/utils/test_llm.py
@@ -1,0 +1,91 @@
+"""Tests for LLM retry behaviour."""
+
+import anthropic
+import httpx
+import openai
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
+
+from ax_prover.config import LLMConfig
+from ax_prover.utils.llm import LLMClient, _is_transient_error
+
+
+def _status_error(cls, status: int) -> Exception:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    return cls("boom", response=httpx.Response(status, request=request), body=None)
+
+
+class TestIsTransientError:
+    """Only failures that can succeed on a retry are classified as transient."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _status_error(anthropic.RateLimitError, 429),
+            _status_error(anthropic.InternalServerError, 500),
+            _status_error(anthropic.APIStatusError, 529),
+            _status_error(openai.RateLimitError, 429),
+            anthropic.APIConnectionError(request=httpx.Request("POST", "https://x")),
+        ],
+    )
+    def test_transient(self, exc):
+        assert _is_transient_error(exc) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _status_error(anthropic.BadRequestError, 400),
+            _status_error(anthropic.AuthenticationError, 401),
+            _status_error(anthropic.NotFoundError, 404),
+            # Unsupported provider_config is rejected client-side before any request
+            ValueError("`thinking={'budget_tokens': ...}` is not supported for claude-opus-5"),
+        ],
+    )
+    def test_permanent(self, exc):
+        assert _is_transient_error(exc) is False
+
+
+class TestClientRetry:
+    """LLMClient retries transient failures and fails fast on permanent ones."""
+
+    @pytest.fixture
+    def client(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        config = LLMConfig(model="anthropic:claude-opus-5", provider_config={})
+        config.retry_config = {
+            "stop_after_attempt": 5,
+            "exponential_jitter_params": {"initial": 0.01, "max": 0.02, "exp_base": 2.0},
+        }
+        return LLMClient(config)
+
+    async def test_retries_transient_until_success(self, client):
+        attempts = []
+
+        def flaky(_):
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise _status_error(anthropic.RateLimitError, 429)
+            return AIMessage(content="recovered")
+
+        client._get_runnable = lambda **kwargs: RunnableLambda(flaky)
+
+        response = await client.ainvoke([])
+
+        assert response.content == "recovered"
+        assert len(attempts) == 3
+
+    async def test_permanent_error_is_not_retried(self, client):
+        """A permanent error must surface immediately rather than retry for hours."""
+        attempts = []
+
+        def always_invalid(_):
+            attempts.append(1)
+            raise ValueError("budget_tokens is not supported for claude-opus-5")
+
+        client._get_runnable = lambda **kwargs: RunnableLambda(always_invalid)
+
+        with pytest.raises(ValueError, match="budget_tokens"):
+            await client.ainvoke([])
+
+        assert len(attempts) == 1


### PR DESCRIPTION
Fixes #42.

`with_retry` retries every `Exception`, so a permanent error was retried 10,000 times with no logging. In #42 an unsupported `thinking.budget_tokens` raised a client-side `ValueError` in 0.1s; the retry loop turned that into a multi-hour silent hang.

- Retry only transient failures (429, 5xx, connection errors); everything else raises immediately.
- Log each retry, so a retry storm is never silent again.
- Structured output now uses `output_config.format`. It is accepted by every model we use; `output_format` is deprecated and removed in langchain-anthropic 2.0, so the old path would have broken on a dependency bump.

Verified against the live API: the #42 repro now fails in 0.1s with the actual message, 429s still retry and recover, permanent errors are attempted once. Reproduced the original hang on both `main` and the released 0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM invocation and retry behavior for the whole prover; misclassified errors could either stop retries too early or still waste time, though tests cover the main cases.
> 
> **Overview**
> **LLM retries** no longer use LangChain `with_retry` on the runnable. `LLMClient.ainvoke` wraps calls in **tenacity** `AsyncRetrying` that retries only **429, 5xx, and connection errors** via `_is_transient_error`; auth, 4xx, and client-side errors (e.g. invalid `thinking` config) surface on the first attempt. Each backoff is logged at WARNING so long retry loops are visible.
> 
> `DEFAULT_LLM_RETRY_CONFIG` drops the old `wait_exponential_jitter` flag in favor of the existing `exponential_jitter_params` shape used by tenacity.
> 
> **Anthropic structured output** always binds `output_config.format` with a JSON schema, removing the Claude 4.5 vs 4.6 `output_format` split ahead of langchain-anthropic 2.0.
> 
> Unit tests cover transient vs permanent classification and that the client retries 429s but not permanent `ValueError`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a437c5a656b9e86767f76d98c598eca904a46bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->